### PR TITLE
Add docs to  `effect/HashSet` module

### DIFF
--- a/.changeset/real-apples-count.md
+++ b/.changeset/real-apples-count.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Improved TsDoc documentation for `HashSet` module.

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -272,6 +272,7 @@ export interface HashSet<out A> extends Iterable<A>, Equal, Pipeable, Inspectabl
 /**
  * @since 2.0.0
  * @category refinements
+ * @memberof HashSet
  */
 export const isHashSet: {
   <A>(u: Iterable<A>): u is HashSet<A>
@@ -934,6 +935,7 @@ export const size: <A>(self: HashSet<A>) => number = HS.size
 /**
  * Marks the `HashSet` as mutable.
  *
+ * @memberof HashSet
  * @since 2.0.0
  */
 export const beginMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.beginMutation
@@ -941,6 +943,7 @@ export const beginMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.beginMutati
 /**
  * Marks the `HashSet` as immutable.
  *
+ * @memberof HashSet
  * @since 2.0.0
  */
 export const endMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.endMutation
@@ -948,6 +951,7 @@ export const endMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.endMutation
 /**
  * Mutates the `HashSet` within the context of the provided function.
  *
+ * @memberof HashSet
  * @since 2.0.0
  */
 export const mutate: {
@@ -1097,6 +1101,7 @@ export const remove: {
  * **NOTE**: the hash and equal of the values in both the set and the iterable
  * must be the same.
  *
+ * @memberof HashSet
  * @since 2.0.0
  */
 export const difference: {
@@ -1113,6 +1118,7 @@ export const difference: {
  * **NOTE**: the hash and equal of the values in both the set and the iterable
  * must be the same.
  *
+ * @memberof HashSet
  * @since 2.0.0
  */
 export const intersection: {
@@ -1129,6 +1135,7 @@ export const intersection: {
  * **NOTE**: the hash and equal of the values in both the set and the iterable
  * must be the same.
  *
+ * @memberof HashSet
  * @since 2.0.0
  */
 export const union: {

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -466,11 +466,80 @@ export const has: {
 /**
  * Check if a predicate holds true for some `HashSet` element.
  *
+ * @memberof HashSet
  * @since 2.0.0
  * @category elements
+ * @example **syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * const set: HashSet.HashSet<number> = HashSet.make(0, 1, 2)
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(
+ *   set,
+ *   HashSet.some((n) => n > 0)
+ * ) // true
+ *
+ * // or piped with the pipe function
+ * set.pipe(HashSet.some((n) => n > 0)) // true
+ *
+ * // or with `data-first` API
+ * HashSet.some(set, (n) => n > 0) // true
+ * ```
+ *
+ * @todo Add time complexity analisys
  */
 export const some: {
+  /**
+   * @example {@link some} `data-last` a.k.a. `pipeable` API
+   *
+   * ```ts
+   * import * as assert from "node:assert/strict"
+   * import { HashSet, pipe } from "effect"
+   *
+   * const set = HashSet.make(0, 1, 2)
+   *
+   * assert.equal(
+   *   pipe(
+   *     set,
+   *     HashSet.some((n) => n > 0)
+   *   ),
+   *   true
+   * )
+   *
+   * assert.equal(
+   *   pipe(
+   *     set,
+   *     HashSet.some((n) => n > 2)
+   *   ),
+   *   false
+   * )
+   * ```
+   */
   <A>(f: Predicate<A>): (self: HashSet<A>) => boolean
+
+  /**
+   * @example {@link some} `data-first` API
+   *
+   * ```ts
+   * import * as assert from "node:assert/strict"
+   * import { HashSet } from "effect"
+   *
+   * const set = HashSet.make(0, 1, 2)
+   *
+   * assert.equal(
+   *   HashSet.some(set, (n) => n > 0),
+   *   true
+   * )
+   *
+   * assert.equal(
+   *   HashSet.some(set, (n) => n > 2),
+   *   false
+   * )
+   * ```
+   */
   <A>(self: HashSet<A>, f: Predicate<A>): boolean
 } = HS.some
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -693,7 +693,7 @@ export const some: {
  * @example **syntax** with {@link Refinement}
  *
  * ```ts
- * import { HashSet, pipe } from "effect"
+ * import { HashSet, pipe, Predicate } from "effect"
  *
  * const numberOrString = HashSet.make(1, "1", "one", "uno")
  *

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1330,11 +1330,64 @@ export const forEach: {
 /**
  * Reduces the specified state over the values of the `HashSet`.
  *
+ * The time complexity is of **`O(n)`**.
+ *
+ * @memberof HashSet
  * @since 2.0.0
  * @category folding
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * const sum = (a: number, b: number): number => a + b
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(HashSet.make(0, 1, 2), HashSet.reduce(0, sum))
+ *
+ * // or with the pipe method
+ * HashSet.make(0, 1, 2).pipe(HashSet.reduce(0, sum))
+ *
+ * // or with `data-first` API
+ * HashSet.reduce(HashSet.make(0, 1, 2), 0, sum)
+ * ```
  */
 export const reduce: {
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * assert.equal(
+   *   pipe(
+   *     HashSet.make(0, 1, 2),
+   *     HashSet.reduce(10, (accumulator, value) => accumulator + value)
+   *   ),
+   *   13
+   * )
+   * ```
+   */
   <A, Z>(zero: Z, f: (accumulator: Z, value: A) => Z): (self: HashSet<A>) => Z
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * assert.equal(
+   *   HashSet.reduce(
+   *     HashSet.make(0, 1, 2),
+   *     -3,
+   *     (accumulator, value) => accumulator + value
+   *   ),
+   *   0
+   * )
+   * ```
+   */
   <A, Z>(self: HashSet<A>, zero: Z, f: (accumulator: Z, value: A) => Z): Z
 } = HS.reduce
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -546,9 +546,47 @@ export const mutate: {
  * Adds a value to the `HashSet`.
  *
  * @since 2.0.0
+ * @see check out the other mutaitons {@link remove} {@link toggle}
  */
 export const add: {
+  /**
+   * @example Add pipable api
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import assert from "node:assert/strict"
+   *
+   * assert.deepStrictEqual(
+   *   pipe(
+   *     HashSet.empty<number>(), // HashSet.HashSet<number>
+   *     HashSet.add(0),
+   *     HashSet.add(1),
+   *     HashSet.add(1),
+   *     HashSet.add(2),
+   *     HashSet.toValues
+   *   ),
+   *   Array.of(0, 1, 2)
+   * )
+   * ```
+   */
   <A>(value: A): (self: HashSet<A>) => HashSet<A>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import assert from "node:assert/strict"
+   *
+   * const empty = HashSet.empty<number>()
+   * const withZero = HashSet.add(empty, 0)
+   * const withOne = HashSet.add(withZero, 1)
+   * const withTwo = HashSet.add(withOne, 2)
+   * const withTwoTwo = HashSet.add(withTwo, 2)
+   *
+   * assert.deepStrictEqual(HashSet.toValues(withTwoTwo), Array.of(0, 1, 2))
+   * ```
+   */
   <A>(self: HashSet<A>, value: A): HashSet<A>
 } = HS.add
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1,4 +1,6 @@
 /**
+ * # HashSet
+ *
  * An immutable `HashSet` provides a collection of unique values with efficient
  * lookup, insertion and removal. Once created, a `HashSet` cannot be modified;
  * any operation that would alter the set instead returns a new `HashSet` with
@@ -14,7 +16,6 @@
  * ## When to Use
  *
  * Use `HashSet` when you need:
- *
  * - A collection with no duplicate values
  * - Efficient membership testing (**`O(1)`** average complexity)
  * - Set operations like union, intersection, and difference
@@ -23,7 +24,6 @@
  * ## Advanced Features
  *
  * HashSet provides operations for:
- *
  * - Transforming sets with map and flatMap
  * - Filtering elements with filter
  * - Combining sets with union, intersection and difference
@@ -270,9 +270,9 @@ export interface HashSet<out A> extends Iterable<A>, Equal, Pipeable, Inspectabl
 }
 
 /**
+ * @memberof HashSet
  * @since 2.0.0
  * @category refinements
- * @memberof HashSet
  */
 export const isHashSet: {
   <A>(u: Iterable<A>): u is HashSet<A>
@@ -394,6 +394,8 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
  *   )
  * ) // Outputs: [1, 2, 3, 4]
  * ```
+ *
+ * @see Other `HashSet` constructors are {@link empty} {@link make}
  */
 export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIterable
 
@@ -510,6 +512,7 @@ export const make: <As extends ReadonlyArray<any>>(...elements: As) => HashSet<A
  * ```
  *
  * @returns A `boolean` signaling the presence of the value in the HashSet
+ * @see Other `HashSet` elements are {@link some} {@link every} {@link isSubset}
  */
 export const has: {
   /**
@@ -574,6 +577,8 @@ export const has: {
  * // or with `data-first` API
  * HashSet.some(set, (n) => n > 0) // true
  * ```
+ *
+ * @see Other `HashSet` elements are {@link has} {@link every} {@link isSubset}
  */
 export const some: {
   /**
@@ -682,6 +687,7 @@ export const some: {
  *
  * @returns A boolean once it has evaluated that whole collection fulfill the
  *   Predicate function
+ * @see Other `HashSet` elements are {@link has} {@link some} {@link isSubset}
  */
 export const every: {
   /**
@@ -809,6 +815,8 @@ export const every: {
  * HashSet.isSubset(set1, set2) // false
  * HashSet.isSubset(set1, set3) // true)
  * ```
+ *
+ * @see Other `HashSet` elements are {@link has} {@link some} {@link every}
  */
 export const isSubset: {
   /**
@@ -875,7 +883,7 @@ export const isSubset: {
  * }
  * ```
  *
- * @see check out the other getters {@link toValues} {@link size}
+ * @see Other `HashSet` getters are {@link toValues} {@link size}
  */
 export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
 
@@ -902,7 +910,7 @@ export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
  * )
  * ```
  *
- * @see check out the other getters {@link values} {@link size}
+ * @see Other `HashSet` getters are {@link values} {@link size}
  */
 export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(self))
 
@@ -928,7 +936,7 @@ export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(sel
  * )
  * ```
  *
- * @see check out the other getters {@link values} {@link toValues}
+ * @see Other `HashSet` getters are {@link values} {@link toValues}
  */
 export const size: <A>(self: HashSet<A>) => number = HS.size
 
@@ -937,6 +945,7 @@ export const size: <A>(self: HashSet<A>) => number = HS.size
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @see Other `HashSet` mutations are {@link add} {@link remove} {@link toggle} {@link endMutation} {@link mutate}
  */
 export const beginMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.beginMutation
 
@@ -945,6 +954,7 @@ export const beginMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.beginMutati
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @see Other `HashSet` mutations are {@link add} {@link remove} {@link toggle} {@link beginMutation} {@link mutate}
  */
 export const endMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.endMutation
 
@@ -953,6 +963,7 @@ export const endMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.endMutation
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @see Other `HashSet` mutations are {@link add} {@link remove} {@link toggle} {@link beginMutation} {@link endMutation}
  */
 export const mutate: {
   <A>(f: (set: HashSet<A>) => void): (self: HashSet<A>) => HashSet<A>
@@ -988,7 +999,7 @@ export const mutate: {
  * HashSet.add(HashSet.empty(), 0)
  * ```
  *
- * @see check out the other mutations {@link remove} {@link toggle}
+ * @see Other `HashSet` mutations are {@link remove} {@link toggle} {@link beginMutation} {@link endMutation} {@link mutate}
  */
 export const add: {
   /**
@@ -1053,6 +1064,8 @@ export const add: {
  * // or with `data-first` API
  * HashSet.remove(HashSet.make(0, 1, 2), 0)
  * ```
+ *
+ * @see Other `HashSet` mutations are {@link add} {@link toggle} {@link beginMutation} {@link endMutation} {@link mutate}
  */
 export const remove: {
   /**
@@ -1103,6 +1116,7 @@ export const remove: {
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @see Other `HashSet` operations are {@link intersection} {@link union}
  */
 export const difference: {
   <A>(that: Iterable<A>): (self: HashSet<A>) => HashSet<A>
@@ -1113,13 +1127,15 @@ export const difference: {
  * Returns a `HashSet` of values which are present in both this set and that
  * `Iterable<A>`.
  *
- * Time complexity: **`O(n)`** where n is the number of elements in the smaller set
+ * Time complexity: **`O(n)`** where n is the number of elements in the smaller
+ * set
  *
  * **NOTE**: the hash and equal of the values in both the set and the iterable
  * must be the same.
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @see Other `HashSet` operations are {@link difference} {@link union}
  */
 export const intersection: {
   <A>(that: Iterable<A>): (self: HashSet<A>) => HashSet<A>
@@ -1127,7 +1143,7 @@ export const intersection: {
 } = HS.intersection
 
 /**
- * Computes the set union `(`self` + `that`)` between this `HashSet` and the
+ * Computes the set union `(`self`+`that`)` between this `HashSet` and the
  * specified `Iterable<A>`.
  *
  * Time complexity: **`O(n)`** where n is the number of elements in the set
@@ -1137,6 +1153,7 @@ export const intersection: {
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @see Other `HashSet` operations are {@link difference} {@link intersection}
  */
 export const union: {
   <A>(that: Iterable<A>): (self: HashSet<A>) => HashSet<A>
@@ -1169,6 +1186,7 @@ export const union: {
  *
  * @returns A new `HashSet` where the toggled value is being either added or
  *   removed based on the initial `HashSet` state.
+ * @see Other `HashSet` mutations are {@link add} {@link remove} {@link beginMutation} {@link endMutation} {@link mutate}
  */
 export const toggle: {
   /**

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -231,28 +231,29 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
  * @example Creating a HashSet from an {@link Array}
  *
  * ```ts
- * import { HashSet } from "effect"
+ * import { HashSet, pipe } from "effect"
  *
- * const array: Iterable<number> = [1, 2, 3, 4, 5, 1, 2, 3] // Note the duplicates
- * const uniqueNumbers = HashSet.fromIterable(array)
- *
- * console.log(HashSet.toValues(uniqueNumbers)) // Output: [1, 2, 3, 4, 5]
+ * console.log(
+ *   pipe(
+ *     [1, 2, 3, 4, 5, 1, 2, 3], // Array<number> is an Iterable<number>;  Note the duplicates.
+ *     HashSet.fromIterable,
+ *     HashSet.toValues
+ *   )
+ * ) // Output: [1, 2, 3, 4, 5]
  * ```
  *
  * @example Creating a HashSet from a {@link Set}
  *
  * ```ts
- * import { HashSet } from "effect"
+ * import { HashSet, pipe } from "effect"
  *
- * const fruitsSet: Iterable<string> = new Set([
- *   "apple",
- *   "banana",
- *   "orange",
- *   "apple"
- * ])
- * const fruitsHashSet = HashSet.fromIterable(fruitsSet)
- *
- * console.log(HashSet.toValues(fruitsHashSet)) // Output: ["apple", "banana", "orange"]
+ * console.log(
+ *   pipe(
+ *     new Set(["apple", "banana", "orange", "apple"]), // Set<string> is an Iterable<string>
+ *     HashSet.fromIterable,
+ *     HashSet.toValues
+ *   )
+ * ) // Output: ["apple", "banana", "orange"]
  * ```
  *
  * @example Creating a HashSet from a {@link Generator}
@@ -272,6 +273,36 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
  *
  * console.log(HashSet.toValues(fibonacciSet))
  * // Outputs: [0, 1, 2, 3, 5, 8, 13, 21, 34] but in unsorted order
+ * ```
+ *
+ * @example Creating a HashSet from another {@link HashSet}
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * console.log(
+ *   pipe(
+ *     // since HashSet implements the Iterable interface, we can use it to create a new HashSet
+ *     HashSet.make(1, 2, 3, 4),
+ *     HashSet.fromIterable,
+ *     HashSet.toValues // turns the HashSet back into an array
+ *   )
+ * ) // Output: [1, 2, 3, 4]
+ * ```
+ *
+ * @example Creating a HashSet from other Effect's data structures like
+ * {@link Chunk}
+ *
+ * ```ts
+ * import { Chunk, HashSet, pipe } from "effect"
+ *
+ * console.log(
+ *   pipe(
+ *     Chunk.make(1, 2, 3, 4), // Iterable<number>
+ *     HashSet.fromIterable,
+ *     HashSet.toValues // turns the HashSet back into an array
+ *   )
+ * ) // Outputs: [1, 2, 3, 4]
  * ```
  */
 export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIterable

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -201,6 +201,7 @@ export const isHashSet: {
 /**
  * Creates an empty `HashSet`.
  *
+ * @memberof HashSet
  * @since 2.0.0
  * @category constructors
  * @example
@@ -228,6 +229,7 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
 /**
  * Creates a new `HashSet` from an iterable collection of values.
  *
+ * @memberof HashSet
  * @since 2.0.0
  * @category constructors
  * @example Creating a HashSet from an {@link Array}
@@ -316,6 +318,7 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
 /**
  * Construct a new `HashSet` from a variable number of values.
  *
+ * @memberof HashSet
  * @since 2.0.0
  * @category constructors
  * @example
@@ -452,6 +455,7 @@ export const isSubset: {
 /**
  * Returns an `IterableIterator` of the values in the `HashSet`.
  *
+ * @memberof HashSet
  * @since 2.0.0
  * @category getters
  * @example
@@ -479,6 +483,7 @@ export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
  *
  * Time complexity of O(n)
  *
+ * @memberof HashSet
  * @since 3.13.0
  * @category getters
  * @example
@@ -504,6 +509,7 @@ export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(sel
 /**
  * Calculates the number of values in the `HashSet`.
  *
+ * @memberof HashSet
  * @since 2.0.0
  * @category getters
  * @example
@@ -559,6 +565,7 @@ export const mutate: {
  * Remember that HashSet is an immutable data structure, so the `add` function,
  * like all other functions that modify the HashSet, will return a new HashSet
  * with the added value.
+ * @memberof HashSet
  * @since 2.0.0
  * @example **Syntax**
  *
@@ -623,6 +630,7 @@ export const add: {
 /**
  * Removes a value from the `HashSet`.
  *
+ * @memberof HashSet
  * @since 2.0.0
  * @example **Syntax**
  *

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1329,20 +1329,96 @@ export const remove: {
 } = HS.remove
 
 /**
- * Computes the set difference between this `HashSet` and the specified
- * `Iterable<A>`.
+ * Computes the set difference `(A - B)` between this `HashSet` and the
+ * specified `Iterable<A>`.
  *
  * Time complexity: **`O(n)`** where n is the number of elements in the set
  *
  * **NOTE**: the hash and equal of the values in both the set and the iterable
- * must be the same.
+ * must be the same; meaning we cannot compute a difference between a `HashSet
+ * of bananas` and a `HashSet of elephants` as they are not the same type and
+ * won't implement the Equal trait in the same way.
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with data-last, a.k.a. pipeable API
+ * pipe(HashSet.make(1, 2, 3), HashSet.difference(HashSet.make(3, 4, 5)))
+ *
+ * // or piped with the pipe function
+ * HashSet.make(1, 2, 3).pipe(HashSet.difference(HashSet.make(3, 4, 5)))
+ *
+ * // or with data-first API
+ * HashSet.difference(HashSet.make(1, 2, 3), HashSet.make(3, 4, 5))
+ * ```
+ *
  * @see Other `HashSet` operations are {@link intersection} {@link union}
  */
 export const difference: {
+  /**
+   * @example {@link difference} `data-last` a.k.a. `pipeable` API
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * // Create two sets with some overlapping elements
+   * const thisSet = HashSet.make(1, 2, 3)
+   * const thatIterable = HashSet.make(3, 4, 5)
+   *
+   * // Compute the difference (elements in thisSet that are not in thatIterable)
+   * const result = pipe(thisSet, HashSet.difference(thatIterable))
+   *
+   * // The result contains only elements from thisSet that are not in thatIterable
+   * assert.deepStrictEqual(HashSet.toValues(result).sort(), [1, 2])
+   *
+   * // The original sets are unchanged
+   * assert.deepStrictEqual(HashSet.toValues(thisSet).sort(), [1, 2, 3])
+   * assert.deepStrictEqual(
+   *   HashSet.toValues(thatIterable).sort(),
+   *   [3, 4, 5]
+   * )
+   *
+   * // You can also use arrays or other iterables
+   * const diffWithArray = pipe(thisSet, HashSet.difference([3, 4]))
+   * assert.deepStrictEqual(HashSet.toValues(diffWithArray).sort(), [1, 2])
+   * ```
+   */
   <A>(that: Iterable<A>): (self: HashSet<A>) => HashSet<A>
+
+  /**
+   * @example {@link difference} `data-first` API
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * // Create two sets with some overlapping elements
+   * const thisSet = HashSet.make(1, 2, 3)
+   * const thatIterable = HashSet.make(3, 4, 5)
+   *
+   * // Compute the difference using data-first API
+   * const result = HashSet.difference(thisSet, thatIterable)
+   *
+   * // The result contains only elements from thisSet that are not in thatIterable
+   * assert.deepStrictEqual(HashSet.toValues(result).sort(), [1, 2])
+   *
+   * // The original sets are unchanged
+   * assert.deepStrictEqual(HashSet.toValues(thisSet).sort(), [1, 2, 3])
+   * assert.deepStrictEqual(
+   *   HashSet.toValues(thatIterable).sort(),
+   *   [3, 4, 5]
+   * )
+   *
+   * // You can also compute the difference in the other direction
+   * const reverseResult = HashSet.difference(thatIterable, thisSet)
+   * assert.deepStrictEqual(HashSet.toValues(reverseResult).sort(), [4, 5])
+   * ```
+   */
   <A>(self: HashSet<A>, that: Iterable<A>): HashSet<A>
 } = HS.difference
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -235,77 +235,81 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
  * @since 2.0.0
  * @category constructors
  * @example
- *   import { Equal, Hash, HashSet, pipe } from "effect"
- *   import assert from "node:assert/strict"
  *
- *   assert.strictEqual(
- *     Equal.equals(
- *       HashSet.make(
- *         Character.of("Alice", "Curious"),
- *         Character.of("Alice", "Curious"),
- *         Character.of("White Rabbit", "Always late"),
- *         Character.of("Mad Hatter", "Tea enthusiast")
- *       ),
- *       // Is the same as adding each character to an empty set
- *       pipe(
- *         HashSet.empty(),
- *         HashSet.add(Character.of("Alice", "Curious")),
- *         HashSet.add(Character.of("Alice", "Curious")), // Alice tried to attend twice!
- *         HashSet.add(Character.of("White Rabbit", "Always late")),
- *         HashSet.add(Character.of("Mad Hatter", "Tea enthusiast"))
- *       )
+ * ```ts
+ * import { Equal, Hash, HashSet, pipe } from "effect"
+ * import assert from "node:assert/strict"
+ *
+ * assert.strictEqual(
+ *   Equal.equals(
+ *     HashSet.make(
+ *       Character.of("Alice", "Curious"),
+ *       Character.of("Alice", "Curious"),
+ *       Character.of("White Rabbit", "Always late"),
+ *       Character.of("Mad Hatter", "Tea enthusiast")
  *     ),
- *     true
- *   )
+ *     // Is the same as adding each character to an empty set
+ *     pipe(
+ *       HashSet.empty(),
+ *       HashSet.add(Character.of("Alice", "Curious")),
+ *       HashSet.add(Character.of("Alice", "Curious")), // Alice tried to attend twice!
+ *       HashSet.add(Character.of("White Rabbit", "Always late")),
+ *       HashSet.add(Character.of("Mad Hatter", "Tea enthusiast"))
+ *     )
+ *   ),
+ *   true,
+ *   "`HashSet.make` and `HashSet.empty() + HashSet.add()` should be equal"
+ * )
  *
- *   assert.strictEqual(
- *     Equal.equals(
- *       HashSet.make(
- *         Character.of("Alice", "Curious"),
- *         Character.of("Alice", "Curious"),
- *         Character.of("White Rabbit", "Always late"),
- *         Character.of("Mad Hatter", "Tea enthusiast")
- *       ),
- *       // Is the same as creating a set from an iterable
- *       HashSet.fromIterable([
- *         Character.of("Alice", "Curious"),
- *         Character.of("Alice", "Curious"),
- *         Character.of("White Rabbit", "Always late"),
- *         Character.of("Mad Hatter", "Tea enthusiast")
- *       ])
+ * assert.strictEqual(
+ *   Equal.equals(
+ *     HashSet.make(
+ *       Character.of("Alice", "Curious"),
+ *       Character.of("Alice", "Curious"),
+ *       Character.of("White Rabbit", "Always late"),
+ *       Character.of("Mad Hatter", "Tea enthusiast")
  *     ),
- *     true
- *   )
+ *     HashSet.fromIterable([
+ *       Character.of("Alice", "Curious"),
+ *       Character.of("Alice", "Curious"),
+ *       Character.of("White Rabbit", "Always late"),
+ *       Character.of("Mad Hatter", "Tea enthusiast")
+ *     ])
+ *   ),
+ *   true,
+ *   "`HashSet.make` and `HashSet.fromIterable` should be equal"
+ * )
  *
- *   class Character implements Equal.Equal {
- *     readonly name: string
- *     readonly trait: string
+ * class Character implements Equal.Equal {
+ *   readonly name: string
+ *   readonly trait: string
  *
- *     constructor(name: string, trait: string) {
- *       this.name = name
- *       this.trait = trait
- *     }
- *
- *     // Define equality based on name, and trait
- *     [Equal.symbol](that: Equal.Equal): boolean {
- *       if (that instanceof Character) {
- *         return (
- *           Equal.equals(this.name, that.name) &&
- *           Equal.equals(this.trait, that.trait)
- *         )
- *       }
- *       return false
- *     }
- *
- *     // Generate a hash code based on the sum of the character's name and trait
- *     [Hash.symbol](): number {
- *       throw Hash.hash(this.name + this.trait)
- *     }
- *
- *     static readonly of = (name: string, trait: string): Character => {
- *       return new Character(name, trait)
- *     }
+ *   constructor(name: string, trait: string) {
+ *     this.name = name
+ *     this.trait = trait
  *   }
+ *
+ *   // Define equality based on name, and trait
+ *   [Equal.symbol](that: Equal.Equal): boolean {
+ *     if (that instanceof Character) {
+ *       return (
+ *         Equal.equals(this.name, that.name) &&
+ *         Equal.equals(this.trait, that.trait)
+ *       )
+ *     }
+ *     return false
+ *   }
+ *
+ *   // Generate a hash code based on the sum of the character's name and trait
+ *   [Hash.symbol](): number {
+ *     throw Hash.hash(this.name + this.trait)
+ *   }
+ *
+ *   static readonly of = (name: string, trait: string): Character => {
+ *     return new Character(name, trait)
+ *   }
+ * }
+ * ```
  *
  * @see Other `HashSet` constructors are {@link fromIterable} {@link empty}
  */

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1266,11 +1266,64 @@ export const flatMap: {
 /**
  * Applies the specified function to the values of the `HashSet`.
  *
+ * The time complexity is of **`O(n)`**.
+ *
+ * @memberof HashSet
  * @since 2.0.0
  * @category traversing
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(HashSet.make(0, 1, 2), HashSet.forEach(console.log)) // logs: 0 1 2
+ *
+ * // or piped with the pipe method
+ * HashSet.make(0, 1, 2).pipe(HashSet.forEach(console.log)) // logs: 0 1 2
+ *
+ * // or with `data-first` API
+ * HashSet.forEach(HashSet.make(0, 1, 2), console.log) // logs: 0 1 2
+ * ```
  */
 export const forEach: {
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const result: Array<number> = []
+   *
+   * pipe(
+   *   HashSet.make(0, 1, 2),
+   *   HashSet.forEach((n): void => {
+   *     result.push(n)
+   *   })
+   * )
+   *
+   * assert.deepStrictEqual(result, [0, 1, 2])
+   * ```
+   */
   <A>(f: (value: A) => void): (self: HashSet<A>) => void
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const result: Array<number> = []
+   *
+   * HashSet.forEach(HashSet.make(0, 1, 2), (n): void => {
+   *   result.push(n)
+   * })
+   *
+   * assert.deepStrictEqual(result, [0, 1, 2])
+   * ```
+   */
   <A>(self: HashSet<A>, f: (value: A) => void): void
 } = HS.forEach
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -608,7 +608,7 @@ export const add: {
    *
    * assert.deepStrictEqual(HashSet.toValues(withTwoTwo), Array.of(0, 1, 2))
    * ```
-   */
+   */ 
   <A>(self: HashSet<A>, value: A): HashSet<A>
 } = HS.add
 
@@ -616,9 +616,58 @@ export const add: {
  * Removes a value from the `HashSet`.
  *
  * @since 2.0.0
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(HashSet.make(0, 1, 2), HashSet.remove(0))
+ *
+ * // or piped with the pipe function
+ * HashSet.make(0, 1, 2).pipe(HashSet.remove(0))
+ *
+ * // or with `data-first` API
+ * HashSet.remove(HashSet.make(0, 1, 2), 0)
+ * ```
+ *
+ * @todo Remind the user of the immutability garanties of the HashSet data type
  */
 export const remove: {
+  /**
+   * @example {@link remove} `data-last` a.k.a. `pipeable` API
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const set = HashSet.make(0, 1, 2)
+   * const result = pipe(set, HashSet.remove(0))
+   *
+   * assert.equal(pipe(result, HashSet.has(0)), false) // it has correctly removed 0
+   * assert.equal(pipe(set, HashSet.has(0)), true) // it does not mutate the original set
+   * assert.equal(pipe(result, HashSet.has(1)), true)
+   * assert.equal(pipe(result, HashSet.has(2)), true)
+   * ```
+   */
   <A>(value: A): (self: HashSet<A>) => HashSet<A>
+
+  /**
+   * @example {@link remove} `data-first` API
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const set = HashSet.make(0, 1, 2)
+   * const result = HashSet.remove(set, 0)
+   *
+   * assert.equal(HashSet.has(result, 0), false) // it has correctly removed 0
+   * assert.equal(HashSet.has(set, 0), true) // it does not mutate the original set
+   * assert.equal(HashSet.has(result, 1), true)
+   * assert.equal(HashSet.has(result, 2), true)
+   * ```
+   */
   <A>(self: HashSet<A>, value: A): HashSet<A>
 } = HS.remove
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1200,11 +1200,66 @@ export const map: {
 /**
  * Chains over the values of the `HashSet` using the specified function.
  *
+ * The time complexity is of **`O(n)`**.
+ *
+ * @memberof HashSet
  * @since 2.0.0
  * @category sequencing
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(
+ *   HashSet.make(0, 1, 2), // HashSet.HashSet<number>
+ *   HashSet.flatMap((n) => Array.of(String(n))) // HashSet.HashSet<string>
+ * )
+ *
+ * // or piped with the pipe method
+ * HashSet.make(0, 1, 2) // HashSet.HashSet<number>
+ *   .pipe(
+ *     HashSet.flatMap((n) => Array.of(String(n))) // HashSet.HashSet<string>
+ *   )
+ *
+ * // or with `data-first` API
+ * HashSet.flatMap(HashSet.make(0, 1, 2), (n) => Array.of(String(n)))
+ * ```
  */
 export const flatMap: {
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe, List } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * assert.deepStrictEqual(
+   *   pipe(
+   *     HashSet.make(0, 1, 2),
+   *     HashSet.flatMap((n) => List.of(String(n * n))) // needs to return an Iterable
+   *   ),
+   *   HashSet.make("0", "1", "4")
+   * )
+   * ```
+   */
   <A, B>(f: (a: A) => Iterable<B>): (self: HashSet<A>) => HashSet<B>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe, List } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * assert.deepStrictEqual(
+   *   HashSet.flatMap(HashSet.make(0, 1, 2), (n) =>
+   *     List.of(String(n * n * n))
+   *   ), // needs to return an Iterable
+   *   HashSet.make("0", "1", "8")
+   * )
+   * ```
+   */
   <A, B>(self: HashSet<A>, f: (a: A) => Iterable<B>): HashSet<B>
 } = HS.flatMap
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -275,7 +275,56 @@ export interface HashSet<out A> extends Iterable<A>, Equal, Pipeable, Inspectabl
  * @category refinements
  */
 export const isHashSet: {
+  /**
+   * Type guard function to determine if a given iterable is a `HashSet`.
+   *
+   * This overload preserves the type of the iterable's elements.
+   *
+   * @example
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   *
+   * const numberIterable: Iterable<1 | 2 | 3> = [1, 2, 3]
+   *
+   * if (
+   *   // if passed an Iterable<A> the type guard that preserves the type parameter <A>
+   *   HashSet.isHashSet(numberIterable)
+   * ) {
+   *   const HashSet: HashSet.HashSet<1 | 2 | 3> = numberIterable
+   * }
+   * ```
+   *
+   * @param u - The iterable input to be checked.
+   * @returns A boolean indicating whether the provided iterable is a `HashSet`.
+   */
   <A>(u: Iterable<A>): u is HashSet<A>
+
+  /**
+   * Type guard function that checks if the provided value is a `HashSet` of
+   * unknown type.
+   *
+   * @example
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   * import assert from "node:assert/strict"
+   *
+   * // Check if a value is a HashSet
+   * const set = HashSet.make(1, 2, 3)
+   *
+   * assert.equal(HashSet.isHashSet(set), true) // true
+   * assert.equal(HashSet.isHashSet(HashSet.empty()), true)
+   *
+   * // Works with any type
+   * assert.equal(HashSet.isHashSet(null), false) // false
+   * assert.equal(HashSet.isHashSet({}), false) // false
+   * assert.equal(HashSet.isHashSet([1, 2, 3]), false) // false
+   * ```
+   *
+   * @param u - The value to check.
+   * @returns A boolean indicating whether the value is a `HashSet<unknown>`.
+   */
   (u: unknown): u is HashSet<unknown>
 } = HS.isHashSet
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1516,7 +1516,7 @@ export const intersection: {
 } = HS.intersection
 
 /**
- * Computes the set union `(`self`+`that`)` between this `HashSet` and the
+ * Computes the set union `( self ∪ that )` between this `HashSet` and the
  * specified `Iterable<A>`.
  *
  * Time complexity: **`O(n)`** where n is the number of elements in the set
@@ -1526,10 +1526,78 @@ export const intersection: {
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with data-last, a.k.a. pipeable API
+ * pipe(HashSet.make(1, 2, 3), HashSet.union(HashSet.make(3, 4, 5)))
+ *
+ * // or piped with the pipe function
+ * HashSet.make(1, 2, 3).pipe(HashSet.union(HashSet.make(3, 4, 5)))
+ *
+ * // or with data-first API
+ * HashSet.union(HashSet.make(1, 2, 3), HashSet.make(3, 4, 5))
+ * ```
+ *
  * @see Other `HashSet` operations are {@link difference} {@link intersection}
  */
 export const union: {
+  /**
+   * @example {@link union} `data-last` a.k.a. `pipeable` API
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * // Create two sets with some overlapping elements
+   * const selfSet = HashSet.make(1, 2, 3)
+   * const thatIterable = HashSet.make(3, 4, 5)
+   *
+   * // Compute the union (all elements from both sets)
+   * const result = pipe(selfSet, HashSet.union(thatIterable))
+   *
+   * // The result contains all elements from both sets (without duplicates)
+   * assert.deepStrictEqual(HashSet.toValues(result).sort(), [1, 2, 3, 4, 5])
+   *
+   * // The original sets are unchanged
+   * assert.deepStrictEqual(HashSet.toValues(selfSet).sort(), [1, 2, 3])
+   * assert.deepStrictEqual(HashSet.toValues(thatIterable).sort(), [3, 4, 5])
+   *
+   * // You can also use arrays or other iterables
+   * const unionWithArray = pipe(selfSet, HashSet.union([4, 5, 6]))
+   * assert.deepStrictEqual(HashSet.toValues(unionWithArray).sort(), [1, 2, 3, 4, 5, 6])
+   * ```
+   */
   <A>(that: Iterable<A>): (self: HashSet<A>) => HashSet<A>
+
+  /**
+   * @example {@link union} `data-first` API
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * // Create two sets with some overlapping elements
+   * const selfSet = HashSet.make(1, 2, 3)
+   * const thatIterable = HashSet.make(3, 4, 5)
+   *
+   * // Compute the union using data-first API
+   * const result = HashSet.union(selfSet, thatIterable)
+   *
+   * // The result contains all elements from both sets (without duplicates)
+   * assert.deepStrictEqual(HashSet.toValues(result).sort(), [1, 2, 3, 4, 5])
+   *
+   * // The original sets are unchanged
+   * assert.deepStrictEqual(HashSet.toValues(selfSet).sort(), [1, 2, 3])
+   * assert.deepStrictEqual(HashSet.toValues(thatIterable).sort(), [3, 4, 5])
+   *
+   * // You can also use arrays or other iterables
+   * const unionWithArray = HashSet.union(selfSet, [4, 5, 6])
+   * assert.deepStrictEqual(HashSet.toValues(unionWithArray).sort(), [1, 2, 3, 4, 5, 6])
+   * ```
+   */
   <A>(self: HashSet<A>, that: Iterable<A>): HashSet<A>
 } = HS.union
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1038,10 +1038,49 @@ export const size: <A>(self: HashSet<A>) => number = HS.size
 export const beginMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.beginMutation
 
 /**
- * Marks the `HashSet` as immutable.
+ * Makes the `HashSet` immutable again.
+ *
+ * After calling `endMutation`, operations like {@link add} and {@link remove}
+ * will create new instances of the `HashSet` instead of modifying the existing
+ * one.
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @example
+ *
+ * ```ts
+ * import { HashSet } from "effect"
+ * import assert from "node:assert/strict"
+ *
+ * // Create a mutable set
+ * const mutableSet = HashSet.beginMutation(HashSet.empty<number>())
+ *
+ * // Add some elements to the mutable set
+ * HashSet.add(mutableSet, 1)
+ * HashSet.add(mutableSet, 2)
+ *
+ * // Before endMutation, operations modify the set in place
+ * const sameSet = HashSet.add(mutableSet, 3)
+ * assert(Object.is(mutableSet, sameSet)) // true - same object reference
+ * assert.deepStrictEqual(HashSet.toValues(mutableSet).sort(), [1, 2, 3])
+ *
+ * // Make the set immutable again
+ * const immutableSet = HashSet.endMutation(mutableSet)
+ *
+ * // endMutation returns the same set instance, now made immutable
+ * assert(Object.is(mutableSet, immutableSet)) // true - same object reference
+ *
+ * // After endMutation, operations create new instances
+ * const newSet = HashSet.add(immutableSet, 4)
+ * assert(!Object.is(immutableSet, newSet)) // false - different object references
+ *
+ * // The original set remains unchanged
+ * assert.deepStrictEqual(HashSet.toValues(immutableSet).sort(), [1, 2, 3])
+ *
+ * // The new set contains the added element
+ * assert.deepStrictEqual(HashSet.toValues(newSet).sort(), [1, 2, 3, 4])
+ * ```
+ *
  * @see Other `HashSet` mutations are {@link add} {@link remove} {@link toggle} {@link beginMutation} {@link mutate}
  */
 export const endMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.endMutation

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1548,17 +1548,168 @@ export const filter: {
  * right side of the resulting `Tuple`, otherwise the value will be placed into
  * the left side.
  *
+ * Time complexity is of **`O(n)`**.
+ *
+ * @memberof HashSet
  * @since 2.0.0
  * @category partitioning
+ * @example **Syntax** with {@link Predicate}
+ *
+ * ```ts
+ * import { HashSet, pipe, Predicate } from "effect"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(
+ *   HashSet.make(0, 1, 2, 3, 4, 5),
+ *   HashSet.partition((n) => n % 2 === 0)
+ * )
+ *
+ * // or with the pipe method
+ * HashSet.make(0, 1, 2, 3, 4, 5).pipe(
+ *   HashSet.partition((n) => n % 2 === 0)
+ * )
+ *
+ * // or with `data-first` API
+ * HashSet.partition(HashSet.make(0, 1, 2, 3, 4, 5), (n) => n % 2 === 0)
+ * ```
+ *
+ * @example **Syntax** with {@link Refinement}
+ *
+ * ```ts
+ * import { HashSet, pipe, Predicate } from "effect"
+ *
+ * const stringRefinement: Predicate.Refinement<string | number, string> = (
+ *   value
+ * ) => typeof value === "string"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(
+ *   HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier"),
+ *   HashSet.partition(stringRefinement)
+ * )
+ *
+ * // or with the pipe method
+ * HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier").pipe(
+ *   HashSet.partition(stringRefinement)
+ * )
+ *
+ * // or with `data-first` API
+ * HashSet.partition(
+ *   HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier"),
+ *   stringRefinement
+ * )
+ * ```
  */
 export const partition: {
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe, Predicate } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const numbersAndStringsHashSet: HashSet.HashSet<number | string> =
+   *   HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier")
+   *
+   * const stringRefinement: Predicate.Refinement<
+   *   string | number,
+   *   string
+   * > = (value) => typeof value === "string"
+   *
+   * const [
+   *   excluded, // HashSet.HashSet<number>
+   *   satisfying // HashSet.HashSet<string>
+   * ] = pipe(numbersAndStringsHashSet, HashSet.partition(stringRefinement))
+   *
+   * assert.equal(pipe(satisfying, HashSet.every(Predicate.isString)), true)
+   * assert.equal(pipe(excluded, HashSet.every(Predicate.isNumber)), true)
+   *
+   * assert.deepStrictEqual(excluded, HashSet.make(1, 2, 3, 4))
+   * assert.deepStrictEqual(
+   *   satisfying,
+   *   HashSet.make("unos", "two", "trois", "vier")
+   * )
+   * ```
+   */
   <A, B extends A>(
     refinement: Refinement<NoInfer<A>, B>
-  ): (self: HashSet<A>) => [excluded: HashSet<Exclude<A, B>>, satisfying: HashSet<B>]
-  <A>(predicate: Predicate<NoInfer<A>>): (self: HashSet<A>) => [excluded: HashSet<A>, satisfying: HashSet<A>]
+  ): (
+    self: HashSet<A>
+  ) => [excluded: HashSet<Exclude<A, B>>, satisfying: HashSet<B>]
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const [excluded, satisfying] = pipe(
+   *   HashSet.make(0, 1, 2, 3, 4, 5),
+   *   HashSet.partition((n) => n % 2 === 0)
+   * )
+   *
+   * assert.deepStrictEqual(excluded, HashSet.make(1, 3, 5))
+   * assert.deepStrictEqual(satisfying, HashSet.make(0, 2, 4))
+   * ```
+   */
+  <A>(
+    predicate: Predicate<NoInfer<A>>
+  ): (self: HashSet<A>) => [excluded: HashSet<A>, satisfying: HashSet<A>]
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe, Predicate } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const numbersAndStringsHashSet: HashSet.HashSet<number | string> =
+   *   HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier")
+   *
+   * const stringRefinement: Predicate.Refinement<
+   *   string | number,
+   *   string
+   * > = (value) => typeof value === "string"
+   *
+   * const [
+   *   excluded, // HashSet.HashSet<number>
+   *   satisfying // HashSet.HashSet<string>
+   * ] = HashSet.partition(numbersAndStringsHashSet, stringRefinement)
+   *
+   * assert.equal(HashSet.every(satisfying, Predicate.isString), true)
+   * assert.equal(HashSet.every(excluded, Predicate.isNumber), true)
+   *
+   * assert.deepStrictEqual(excluded, HashSet.make(1, 2, 3, 4))
+   * assert.deepStrictEqual(
+   *   satisfying,
+   *   HashSet.make("unos", "two", "trois", "vier")
+   * )
+   * ```
+   */
   <A, B extends A>(
     self: HashSet<A>,
     refinement: Refinement<A, B>
   ): [excluded: HashSet<Exclude<A, B>>, satisfying: HashSet<B>]
-  <A>(self: HashSet<A>, predicate: Predicate<A>): [excluded: HashSet<A>, satisfying: HashSet<A>]
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const [excluded, satisfying] = HashSet.partition(
+   *   HashSet.make(0, 1, 2, 3, 4, 5),
+   *   (n) => n % 2 === 0
+   * )
+   *
+   * assert.deepStrictEqual(excluded, HashSet.make(1, 3, 5))
+   * assert.deepStrictEqual(satisfying, HashSet.make(0, 2, 4))
+   * ```
+   */
+  <A>(
+    self: HashSet<A>,
+    predicate: Predicate<A>
+  ): [excluded: HashSet<A>, satisfying: HashSet<A>]
 } = HS.partition

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1,60 +1,9 @@
 /**
- * A `HashSet` is a collection of unique values with efficient lookup, insertion
- * and removal.
- *
- * ## Basic Usage
- *
- * HashSet solves the problem of maintaining an unsorted collection where each
- * value appears exactly once, with fast operations for checking membership and
- * adding/removing values.
- *
- * ### Value-Based Equality
- *
- * Unlike JavaScript's built-in {@link Set}, which checks for equality by
- * reference, `HashSet` supports _value-based equality_ through the {@link Equal}
- * interface. This allows objects with the same content to be treated as equal:
- *
- * ```ts
- * import { Data, HashSet, pipe } from "effect"
- *
- * // Creating a HashSet with objects that implement the Equal interface
- * const set: HashSet.HashSet<{
- *   readonly age: number
- *   readonly name: string
- * }> = pipe(
- *   HashSet.empty(),
- *   HashSet.add(Data.struct({ name: "Alice", age: 30 })),
- *   HashSet.add(Data.struct({ name: "Alice", age: 30 }))
- * )
- *
- * // HashSet recognizes them as equal, so only one element is stored
- * console.log(HashSet.size(set)) // Output: 1
- * ```
- *
- * However, without using the Data module (or another way to implement Equal):
- *
- * ```ts
- * import { HashSet, pipe } from "effect"
- *
- * // Objects that do NOT implement the Equal interface const set =
- * const set = pipe(
- *   HashSet.empty(),
- *   HashSet.add({ name: "Alice", age: 30 }),
- *   HashSet.add({ name: "Alice", age: 30 })
- * )
- *
- * // Objects are compared by reference, so two elements are stored
- * console.log(HashSet.size(set)) // Output: 2
- * ```
- *
- * ## When to Use
- *
- * Use HashSet when you need:
- *
- * - A collection with no duplicate values
- * - Efficient membership testing (O(1) average complexity)
- * - Set operations like union, intersection, and difference
- * - An immutable data structure that preserves functional programming patterns
+ * An immutable `HashSet` provides a collection of unique values. Once created,
+ * a `HashSet` cannot be modified; any operation that would alter the set
+ * instead returns a new `HashSet` with the changes. This immutability offers
+ * benefits like predictable state management and easier reasoning about your
+ * code.
  *
  * ## Operations Reference
  *
@@ -93,25 +42,170 @@
  * |              |                      |                                             |            |
  * | partitioning | {@link partition}    | Splits into two sets by a predicate         | O(n)       |
  *
- * ## Advanced Features
- *
- * HashSet provides operations for:
- *
- * - Transforming sets with map and flatMap
- * - Filtering elements with filter
- * - Combining sets with union, intersection and difference
- * - Performance optimizations via mutable operations in controlled contexts
- *
- * ## Performance Characteristics
- *
- * - Lookup operations (has): O(1) average time complexity
- * - Insertion operations (add): O(1) average time complexity
- * - Removal operations (remove): O(1) average time complexity
- * - Set operations (union, intersection): O(n) where n is the size of the smaller
- *   set
- * - Iteration: O(n) where n is the size of the set
- *
  * ## Notes
+ *
+ * **Immutability for Beginners:**
+ *
+ * When you perform an operation that seems like it should modify the `HashSet`
+ * (like {@link add `HashSet.add`} or {@link remove `HashSet.remove`}), it doesn't
+ * change the original set. Instead, it creates and returns a _new_ `HashSet`
+ * with the updated elements. This makes your code more predictable.
+ *
+ * ### Interoperability:
+ *
+ * #### With the Effect Library:
+ *
+ * This `HashSet` is designed to work seamlessly within the Effect ecosystem. It
+ * implements the {@link Iterable}, {@link Equal}, {@link Pipeable}, and
+ * {@link Inspectable} traits from Effect. This ensures compatibility with other
+ * Effect data structures and functionalities. For example, you can easily use
+ * Effect's `pipe` method to chain operations on the `HashSet`.
+ *
+ * **Equality of Elements with Effect's {@link Equal `Equal`} Trait:**
+ *
+ * This `HashSet` relies on Effect's {@link Equal} trait to determine the
+ * uniqueness of elements within the set. The way equality is checked depends on
+ * the type of the elements:
+ *
+ * - **Primitive Values:** For primitive JavaScript values like strings, numbers,
+ *   booleans, `null`, and `undefined`, equality is determined by their value
+ *   (similar to the `===` operator).
+ * - **Objects and Custom Types:** For objects and other custom types, equality is
+ *   determined by whether those types implement the {@link Equal} interface
+ *   themselves. If an element type implements `Equal`, the `HashSet` will
+ *   delegate to that implementation to perform the equality check. This allows
+ *   you to define custom logic for determining when two instances of your
+ *   objects should be considered equal based on their properties, rather than
+ *   just their object identity.
+ *
+ * ```ts
+ * import { Equal, Hash, HashSet } from "effect"
+ *
+ * class Person implements Equal.Equal {
+ *   constructor(
+ *     readonly id: number, // Unique identifier
+ *     readonly name: string,
+ *     readonly age: number
+ *   ) {}
+ *
+ *   // Define equality based on id, name, and age
+ *   [Equal.symbol](that: Equal.Equal): boolean {
+ *     if (that instanceof Person) {
+ *       return (
+ *         Equal.equals(this.id, that.id) &&
+ *         Equal.equals(this.name, that.name) &&
+ *         Equal.equals(this.age, that.age)
+ *       )
+ *     }
+ *     return false
+ *   }
+ *
+ *   // Generate a hash code based on the unique id
+ *   [Hash.symbol](): number {
+ *     return Hash.hash(this.id)
+ *   }
+ * }
+ *
+ * // Creating a HashSet with objects that implement the Equal interface
+ * const set = HashSet.empty().pipe(
+ *   HashSet.add(new Person(1, "Alice", 30)),
+ *   HashSet.add(new Person(1, "Alice", 30))
+ * )
+ *
+ * // HashSet recognizes them as equal, so only one element is stored
+ * console.log(HashSet.size(set))
+ * // Output: 1
+ * ```
+ *
+ * **Simplifying Equality and Hashing with `Data` and `Schema`:**
+ *
+ * Effect's {@link Data} and {@link Schema `Schema.Data`} modules offer powerful
+ * ways to automatically handle the implementation of both the {@link Equal} and
+ * {@link Hash} traits for your custom data structures.
+ *
+ * - **`Data` Module:** By using constructors like `Data.struct`, `Data.tuple`,
+ *   `Data.array`, or `Data.case` to define your data types, Effect
+ *   automatically generates the necessary implementations for value-based
+ *   equality and consistent hashing. This significantly reduces boilerplate and
+ *   ensures correctness.
+ *
+ * ```ts
+ * import { HashSet, Data, Equal } from "effect"
+ * import assert from "node:assert/strict"
+ *
+ * // Data.* implements the `Equal` traits for us
+ * const person1 = Data.struct({ id: 1, name: "Alice", age: 30 })
+ * const person2 = Data.struct({ id: 1, name: "Alice", age: 30 })
+ *
+ * assert(Equal.equals(person1, person2))
+ *
+ * const set = HashSet.empty().pipe(
+ *   HashSet.add(person1),
+ *   HashSet.add(person2)
+ * )
+ *
+ * // HashSet recognizes them as equal, so only one element is stored
+ * console.log(HashSet.size(set)) // Output: 1
+ * ```
+ *
+ * - **`Schema` Module:** When defining data schemas using the {@link Schema}
+ *   module, you can use `Schema.Data` to automatically include the `Equal` and
+ *   `Hash` traits in the decoded objects. This is particularly important when
+ *   working with `HashSet`. **For decoded objects to be correctly recognized as
+ *   equal within a `HashSet`, ensure that the schema for those objects is
+ *   defined using `Schema.Data`.**
+ *
+ * ```ts
+ * import { Equal, HashSet, Schema } from "effect"
+ * import assert from "node:assert/strict"
+ *
+ * // Schema.Data implements the `Equal` traits for us
+ * const PersonSchema = Schema.Data(
+ *   Schema.Struct({
+ *     id: Schema.Number,
+ *     name: Schema.String,
+ *     age: Schema.Number
+ *   })
+ * )
+ *
+ * const Person = Schema.decode(PersonSchema)
+ *
+ * const person1 = Person({ id: 1, name: "Alice", age: 30 })
+ * const person2 = Person({ id: 1, name: "Alice", age: 30 })
+ *
+ * assert(Equal.equals(person1, person2)) // Output: true
+ *
+ * const set = HashSet.empty().pipe(
+ *   HashSet.add(person1),
+ *   HashSet.add(person2)
+ * )
+ *
+ * // HashSet thanks to Schema.Data implementation of the `Equal` trait, recognizes the two Person as equal, so only one element is stored
+ * console.log(HashSet.size(set)) // Output: 1
+ * ```
+ *
+ * #### With the JavaScript Runtime:
+ *
+ * To interoperate with the regular JavaScript runtime, Effect's `HashSet`
+ * provides methods to access its elements in formats readily usable by
+ * JavaScript APIs: {@link values `HashSet.values`},
+ * {@link toValues `HashSet.toValues`}
+ *
+ * ```ts
+ * import { HashSet } from "effect"
+ *
+ * const hashSet: HashSet.HashSet<number> = HashSet.make(1, 2, 3)
+ *
+ * // Using HashSet.values to convert HashSet.HashSet<A> to IterableIterator<A>
+ * const iterable: IterableIterator<number> = HashSet.values(hashSet)
+ *
+ * console.log(...iterable) // Logs:  1 2 3
+ *
+ * // Using HashSet.toValues to convert HashSet.HashSet<A> to Array<A>
+ * const array: Array<number> = HashSet.toValues(hashSet)
+ *
+ * console.log(array) // Logs: [ 1, 2, 3 ]
+ * ```
  *
  * The HashSet data structure implements the following traits:
  *

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -16,7 +16,7 @@
  * Use `HashSet` when you need:
  *
  * - A collection with no duplicate values
- * - Efficient membership testing (O(1) average complexity)
+ * - Efficient membership testing (**`O(1)`** average complexity)
  * - Set operations like union, intersection, and difference
  * - An immutable data structure that preserves functional programming patterns
  *
@@ -31,12 +31,12 @@
  *
  * ## Performance Characteristics
  *
- * - **Lookup** operations ({@link has}): **O(1)** average time complexity
- * - **Insertion** operations ({@link add}): **O(1)** average time complexity
- * - **Removal** operations ({@link remove}): **O(1)** average time complexity
- * - **Set** operations ({@link union}, {@link intersection}): **O(n)** where n is
+ * - **Lookup** operations ({@link has}): **`O(1)`** average time complexity
+ * - **Insertion** operations ({@link add}): **`O(1)`** average time complexity
+ * - **Removal** operations ({@link remove}): **`O(1)`** average time complexity
+ * - **Set** operations ({@link union}, {@link intersection}): **`O(n)`** where n is
  *   the size of the smaller set
- * - **Iteration**: **O(n)** where n is the size of the set
+ * - **Iteration**: **`O(n)`** where n is the size of the set
  *
  * The HashSet data structure implements the following traits:
  *
@@ -281,6 +281,8 @@ export const isHashSet: {
 /**
  * Creates an empty `HashSet`.
  *
+ * Time complexity: **`O(1)`**
+ *
  * @memberof HashSet
  * @since 2.0.0
  * @category constructors
@@ -302,12 +304,13 @@ export const isHashSet: {
  * ```
  *
  * @see Other `HashSet` constructors are {@link make} {@link fromIterable}
- * @todo Remember to add time complexity analysis
  */
 export const empty: <A = never>() => HashSet<A> = HS.empty
 
 /**
  * Creates a new `HashSet` from an iterable collection of values.
+ *
+ * Time complexity: **`O(n)`** where n is the number of elements in the iterable
  *
  * @memberof HashSet
  * @since 2.0.0
@@ -390,13 +393,13 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
  *   )
  * ) // Outputs: [1, 2, 3, 4]
  * ```
- *
- * @todo Remember to add time complexity analysis
  */
 export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIterable
 
 /**
  * Construct a new `HashSet` from a variable number of values.
+ *
+ * Time complexity: **`O(n)`** where n is the number of elements
  *
  * @memberof HashSet
  * @since 2.0.0
@@ -479,12 +482,13 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
  * ```
  *
  * @see Other `HashSet` constructors are {@link fromIterable} {@link empty}
- * @todo Remember to add time complexity analysis
  */
 export const make: <As extends ReadonlyArray<any>>(...elements: As) => HashSet<As[number]> = HS.make
 
 /**
  * Checks if the specified value exists in the `HashSet`.
+ *
+ * Time complexity: **`O(1)`** average
  *
  * @memberof HashSet
  * @since 2.0.0
@@ -505,7 +509,6 @@ export const make: <As extends ReadonlyArray<any>>(...elements: As) => HashSet<A
  * ```
  *
  * @returns A `boolean` signaling the presence of the value in the HashSet
- * @todo Add time complexity analysis
  */
 export const has: {
   /**
@@ -546,6 +549,8 @@ export const has: {
 /**
  * Check if a predicate holds true for some `HashSet` element.
  *
+ * Time complexity: **`O(n)`** where n is the number of elements in the set
+ *
  * @memberof HashSet
  * @since 2.0.0
  * @category elements
@@ -568,8 +573,6 @@ export const has: {
  * // or with `data-first` API
  * HashSet.some(set, (n) => n > 0) // true
  * ```
- *
- * @todo Add time complexity analysis
  */
 export const some: {
   /**
@@ -626,7 +629,7 @@ export const some: {
 /**
  * Check if a predicate holds true for every `HashSet` element.
  *
- * Time complexity is **O(n)** as it need to traverse the whole HashSet
+ * Time complexity is **`O(n)`** as it needs to traverse the whole HashSet
  * collection
  *
  * @memberof HashSet
@@ -779,7 +782,7 @@ export const every: {
  *
  * **NOTE**: the hash and equal of both sets must be the same.
  *
- * Time complexity analysis is of `O(n)`
+ * Time complexity analysis is of **`O(n)`**
  *
  * @memberof HashSet
  * @since 2.0.0
@@ -851,6 +854,8 @@ export const isSubset: {
 /**
  * Returns an `IterableIterator` of the values in the `HashSet`.
  *
+ * Time complexity: **`O(1)`**
+ *
  * @memberof HashSet
  * @since 2.0.0
  * @category getters
@@ -870,14 +875,13 @@ export const isSubset: {
  * ```
  *
  * @see check out the other getters {@link toValues} {@link size}
- * @todo Remember to add time complexity analysis
  */
 export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
 
 /**
  * Returns an `Array` of the values within the `HashSet`.
  *
- * Time complexity of O(n)
+ * Time complexity: **`O(n)`** where n is the number of elements in the set
  *
  * @memberof HashSet
  * @since 3.13.0
@@ -898,12 +902,13 @@ export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
  * ```
  *
  * @see check out the other getters {@link values} {@link size}
- * @todo Remember to add time complexity analysis
  */
 export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(self))
 
 /**
  * Calculates the number of values in the `HashSet`.
+ *
+ * Time complexity: **`O(1)`**
  *
  * @memberof HashSet
  * @since 2.0.0
@@ -923,7 +928,6 @@ export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(sel
  * ```
  *
  * @see check out the other getters {@link values} {@link toValues}
- * @todo Remember to add time complexity analysis
  */
 export const size: <A>(self: HashSet<A>) => number = HS.size
 
@@ -954,6 +958,8 @@ export const mutate: {
 /**
  * Adds a value to the `HashSet`.
  *
+ * Time complexity: **`O(1)`** average
+ *
  * @remarks
  * Remember that a `HashSet` is a collection of unique values, so adding a value
  * that already exists in the `HashSet` will not add a duplicate.
@@ -979,7 +985,6 @@ export const mutate: {
  * ```
  *
  * @see check out the other mutations {@link remove} {@link toggle}
- * @todo Remember to add time complexity analysis
  */
 export const add: {
   /**
@@ -1026,6 +1031,8 @@ export const add: {
 /**
  * Removes a value from the `HashSet`.
  *
+ * Time complexity: **`O(1)`** average
+ *
  * @memberof HashSet
  * @since 2.0.0
  * @example **Syntax**
@@ -1042,10 +1049,6 @@ export const add: {
  * // or with `data-first` API
  * HashSet.remove(HashSet.make(0, 1, 2), 0)
  * ```
- *
- * @todo Remind the user of the immutability guaranties of the HashSet data type
- *
- * @todo Add time complexity analysis
  */
 export const remove: {
   /**
@@ -1089,6 +1092,8 @@ export const remove: {
  * Computes the set difference between this `HashSet` and the specified
  * `Iterable<A>`.
  *
+ * Time complexity: **`O(n)`** where n is the number of elements in the set
+ *
  * **NOTE**: the hash and equal of the values in both the set and the iterable
  * must be the same.
  *
@@ -1102,6 +1107,8 @@ export const difference: {
 /**
  * Returns a `HashSet` of values which are present in both this set and that
  * `Iterable<A>`.
+ *
+ * Time complexity: **`O(n)`** where n is the number of elements in the smaller set
  *
  * **NOTE**: the hash and equal of the values in both the set and the iterable
  * must be the same.
@@ -1117,6 +1124,8 @@ export const intersection: {
  * Computes the set union `(`self` + `that`)` between this `HashSet` and the
  * specified `Iterable<A>`.
  *
+ * Time complexity: **`O(n)`** where n is the number of elements in the set
+ *
  * **NOTE**: the hash and equal of the values in both the set and the iterable
  * must be the same.
  *
@@ -1131,6 +1140,8 @@ export const union: {
  * Checks if a value is present in the `HashSet`. If it is present, the value
  * will be removed from the `HashSet`, otherwise the value will be added to the
  * `HashSet`.
+ *
+ * Time complexity: **`O(1)`** average
  *
  * @memberof HashSet
  * @since 2.0.0
@@ -1151,9 +1162,6 @@ export const union: {
  *
  * @returns A new `HashSet` where the toggled value is being either added or
  *   removed based on the initial `HashSet` state.
- * @todo Add time space complexity analysis
- *
- * @todo Remember to point out that HasSet is an immutable data structure
  */
 export const toggle: {
   /**

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -546,13 +546,150 @@ export const some: {
 /**
  * Check if a predicate holds true for every `HashSet` element.
  *
+ * Time complexity is **O(n)** as it need to traverse the whole HashSet
+ * collection
+ *
+ * @memberof HashSet
  * @since 2.0.0
  * @category elements
+ * @example **syntax** with {@link Refinement}
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * const numberOrString = HashSet.make(1, "1", "one", "uno")
+ *
+ * // with `data-last`, a.k.a. `pipeable` API and `Refinement`
+ * pipe(
+ *   numberOrString, // HashSet.HashSet<number | string>
+ *   HashSet.every(Predicate.isString)
+ * ) // HashSet.HashSet<string>
+ *
+ * // or piped with the pipe function and  `Refinement`
+ * numberOrString // HashSet.HashSet<number | string>
+ *   .pipe(HashSet.every(Predicate.isString)) // HashSet.HashSet<string>
+ *
+ * // or with `data-first` API and `Refinement`
+ * HashSet.every(
+ *   numberOrString, // HashSet.HashSet<number | string>
+ *   Predicate.isString
+ * ) // HashSet.HashSet<string>
+ * ```
+ *
+ * @example **syntax** with {@link Predicate}
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * const set = HashSet.make(1, 2, 3)
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(
+ *   set,
+ *   HashSet.every((n) => n >= 0)
+ * ) // true
+ *
+ * // or piped with the pipe function
+ * set.pipe(HashSet.every((n) => n >= 0)) // true
+ *
+ * // or with `data-first` API
+ * HashSet.every(set, (n) => n >= 0) // true
+ * ```
+ *
+ * @returns A boolean once it has evaluated that whole collecion fullfill the
+ *   Predicate function
  */
 export const every: {
-  <A, B extends A>(refinement: Refinement<NoInfer<A>, B>): (self: HashSet<A>) => self is HashSet<B>
+  /**
+   * @example
+   *
+   * ```ts
+   * import * as assert from "node:assert/strict"
+   * import { Effect, HashSet, pipe, Predicate } from "effect"
+   *
+   * const numberOrString: HashSet.HashSet<number | string> = HashSet.make(
+   *   1,
+   *   "1",
+   *   "one",
+   *   "uno"
+   * )
+   *
+   * assert.equal(
+   *   pipe(
+   *     numberOrString, // HashSet.HashSet<number | string>
+   *     HashSet.every(Predicate.isString)
+   *   ), // HashSet.HashSet<string>
+   *   false
+   * )
+   * ```
+   */
+  <A, B extends A>(
+    refinement: Refinement<NoInfer<A>, B>
+  ): (self: HashSet<A>) => self is HashSet<B>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import * as assert from "node:assert/strict"
+   * import { HashSet, pipe } from "effect"
+   *
+   * const set = HashSet.make(0, 1, 2)
+   *
+   * assert.equal(
+   *   pipe(
+   *     set,
+   *     HashSet.every((n) => n >= 0)
+   *   ),
+   *   true
+   * )
+   * ```
+   */
   <A>(predicate: Predicate<A>): (self: HashSet<A>) => boolean
-  <A, B extends A>(self: HashSet<A>, refinement: Refinement<A, B>): self is HashSet<B>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import * as assert from "node:assert/strict"
+   * import { Effect, HashSet, pipe, Predicate } from "effect"
+   *
+   * const numberOrString: HashSet.HashSet<number | string> = HashSet.make(
+   *   1,
+   *   "1",
+   *   "one",
+   *   "uno"
+   * )
+   *
+   * assert.equal(
+   *   HashSet.every(
+   *     numberOrString, // HashSet.HashSet<number | string>
+   *     Predicate.isString
+   *   ), // HashSet.HashSet<string>
+   *   false
+   * )
+   * ```
+   */
+  <A, B extends A>(
+    self: HashSet<A>,
+    refinement: Refinement<A, B>
+  ): self is HashSet<B>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import * as assert from "node:assert/strict"
+   * import { HashSet } from "effect"
+   *
+   * const set = HashSet.make(0, 1, 2)
+   *
+   * assert.equal(
+   *   HashSet.every(set, (n) => n >= 0),
+   *   true
+   * )
+   * ```
+   */
   <A>(self: HashSet<A>, predicate: Predicate<A>): boolean
 } = HS.every
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1424,7 +1424,7 @@ export const difference: {
 
 /**
  * Returns a `HashSet` of values which are present in both this set and that
- * `Iterable<A>`.
+ * `Iterable<A>`. Computes set intersection (A ∩ B)
  *
  * Time complexity: **`O(n)`** where n is the number of elements in the smaller
  * set
@@ -1434,10 +1434,84 @@ export const difference: {
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with data-last, a.k.a. pipeable API
+ * pipe(HashSet.make(1, 2, 3), HashSet.intersection(HashSet.make(2, 3, 4)))
+ *
+ * // or piped with the pipe function
+ * HashSet.make(1, 2, 3).pipe(HashSet.intersection(HashSet.make(2, 3, 4)))
+ *
+ * // or with data-first API
+ * HashSet.intersection(HashSet.make(1, 2, 3), HashSet.make(2, 3, 4))
+ * ```
+ *
  * @see Other `HashSet` operations are {@link difference} {@link union}
  */
 export const intersection: {
+  /**
+   * @example {@link intersection} `data-last` a.k.a. `pipeable` API
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * // Create two sets with some overlapping elements
+   * const set1 = HashSet.make(1, 2, 3)
+   * const set2 = HashSet.make(2, 3, 4)
+   *
+   * // Compute the intersection (elements that are in both sets)
+   * const result = pipe(set1, HashSet.intersection(set2))
+   *
+   * // The result contains only elements that are in both sets
+   * assert.deepStrictEqual(HashSet.toValues(result).sort(), [2, 3])
+   *
+   * // The original sets are unchanged
+   * assert.deepStrictEqual(HashSet.toValues(set1).sort(), [1, 2, 3])
+   * assert.deepStrictEqual(HashSet.toValues(set2).sort(), [2, 3, 4])
+   *
+   * // You can also use arrays or other iterables
+   * const intersectWithArray = pipe(set1, HashSet.intersection([2, 3, 5]))
+   * assert.deepStrictEqual(
+   *   HashSet.toValues(intersectWithArray).sort(),
+   *   [2, 3]
+   * )
+   * ```
+   */
   <A>(that: Iterable<A>): (self: HashSet<A>) => HashSet<A>
+
+  /**
+   * @example {@link intersection} `data-first` API
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * // Create two sets with some overlapping elements
+   * const set1 = HashSet.make(1, 2, 3)
+   * const set2 = HashSet.make(2, 3, 4)
+   *
+   * // Compute the intersection using data-first API
+   * const result = HashSet.intersection(set1, set2)
+   *
+   * // The result contains only elements that are in both sets
+   * assert.deepStrictEqual(HashSet.toValues(result).sort(), [2, 3])
+   *
+   * // The original sets are unchanged
+   * assert.deepStrictEqual(HashSet.toValues(set1).sort(), [1, 2, 3])
+   * assert.deepStrictEqual(HashSet.toValues(set2).sort(), [2, 3, 4])
+   *
+   * // You can also use arrays or other iterables
+   * const intersectWithArray = HashSet.intersection(set1, [2, 3, 5])
+   * assert.deepStrictEqual(
+   *   HashSet.toValues(intersectWithArray).sort(),
+   *   [2, 3]
+   * )
+   * ```
+   */
   <A>(self: HashSet<A>, that: Iterable<A>): HashSet<A>
 } = HS.intersection
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1136,11 +1136,64 @@ export const toggle: {
 /**
  * Maps over the values of the `HashSet` using the specified function.
  *
+ * The time complexity is of **`O(n)`**.
+ *
+ * @memberof HashSet
  * @since 2.0.0
  * @category mapping
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(
+ *   HashSet.make(0, 1, 2), // HashSet.HashSet<number>
+ *   HashSet.map(String) // HashSet.HashSet<string>
+ * )
+ *
+ * // or piped with the pipe method
+ * HashSet.make(0, 1, 2).pipe(HashSet.map(String))
+ *
+ * // or with `data-first` API
+ * HashSet.map(HashSet.make(0, 1, 2), String)
+ * ```
  */
 export const map: {
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * assert.deepStrictEqual(
+   *   pipe(
+   *     HashSet.make(0, 1, 2), //    HashSet.HashSet<number>
+   *     HashSet.map((n) => String(n + 1)) // HashSet.HashSet<String>
+   *   ),
+   *   HashSet.make("1", "2", "3")
+   * )
+   * ```
+   */
   <A, B>(f: (a: A) => B): (self: HashSet<A>) => HashSet<B>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * assert.deepStrictEqual(
+   *   HashSet.map(
+   *     HashSet.make(0, 1, 2), //    HashSet.HashSet<number>
+   *     (n) => String(n + 1)
+   *   ), // HashSet.HashSet<String>
+   *   HashSet.make("1", "2", "3")
+   * )
+   * ```
+   */
   <A, B>(self: HashSet<A>, f: (a: A) => B): HashSet<B>
 } = HS.map
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -221,6 +221,7 @@ export const isHashSet: {
  * ```
  *
  * @see Other `HashSet` constructors are {@link make} {@link fromIterable}
+ * @todo Remember to add time complexity analisys
  */
 export const empty: <A = never>() => HashSet<A> = HS.empty
 
@@ -307,6 +308,8 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
  *   )
  * ) // Outputs: [1, 2, 3, 4]
  * ```
+ *
+ * @todo Remember to add time complexity analisys
  */
 export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIterable
 
@@ -393,6 +396,7 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
  * ```
  *
  * @see Other `HashSet` constructors are {@link fromIterable} {@link empty}
+ * @todo Remember to add time complexity analisys
  */
 export const make: <As extends ReadonlyArray<any>>(...elements: As) => HashSet<As[number]> = HS.make
 
@@ -466,6 +470,7 @@ export const isSubset: {
  * ```
  *
  * @see check out the other gettes {@link toValues} {@link size}
+ * @todo Remember to add time complexity analisys
  */
 export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
 
@@ -492,6 +497,7 @@ export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
  * ```
  *
  * @see check out the other gettes {@link values} {@link size}
+ * @todo Remember to add time complexity analisys
  */
 export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(self))
 
@@ -515,6 +521,7 @@ export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(sel
  * ```
  *
  * @see check out the other gettes {@link values} {@link toValues}
+ * @todo Remember to add time complexity analisys
  */
 export const size: <A>(self: HashSet<A>) => number = HS.size
 
@@ -569,6 +576,7 @@ export const mutate: {
  * ```
  *
  * @see check out the other mutations {@link remove} {@link toggle}
+ * @todo Remember to add time complexity analisys
  */
 export const add: {
   /**
@@ -632,6 +640,8 @@ export const add: {
  * ```
  *
  * @todo Remind the user of the immutability garanties of the HashSet data type
+ *
+ * @todo Add time complexity analisys
  */
 export const remove: {
   /**

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -260,6 +260,8 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
  * @example Creating a HashSet from a {@link Generator}
  *
  * ```ts
+ * import { HashSet } from "effect"
+ *
  * // Generator functions return iterables
  * function* fibonacci(n: number): Generator<number, void, unknown> {
  *   let [a, b] = [0, 1]
@@ -319,6 +321,36 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
  * import { Equal, Hash, HashSet, pipe } from "effect"
  * import assert from "node:assert/strict"
  *
+ * class Character implements Equal.Equal {
+ *   readonly name: string
+ *   readonly trait: string
+ *
+ *   constructor(name: string, trait: string) {
+ *     this.name = name
+ *     this.trait = trait
+ *   }
+ *
+ *   // Define equality based on name, and trait
+ *   [Equal.symbol](that: Equal.Equal): boolean {
+ *     if (that instanceof Character) {
+ *       return (
+ *         Equal.equals(this.name, that.name) &&
+ *         Equal.equals(this.trait, that.trait)
+ *       )
+ *     }
+ *     return false
+ *   }
+ *
+ *   // Generate a hash code based on the sum of the character's name and trait
+ *   [Hash.symbol](): number {
+ *     throw Hash.hash(this.name + this.trait)
+ *   }
+ *
+ *   static readonly of = (name: string, trait: string): Character => {
+ *     return new Character(name, trait)
+ *   }
+ * }
+ *
  * assert.strictEqual(
  *   Equal.equals(
  *     HashSet.make(
@@ -358,36 +390,6 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
  *   true,
  *   "`HashSet.make` and `HashSet.fromIterable` should be equal"
  * )
- *
- * class Character implements Equal.Equal {
- *   readonly name: string
- *   readonly trait: string
- *
- *   constructor(name: string, trait: string) {
- *     this.name = name
- *     this.trait = trait
- *   }
- *
- *   // Define equality based on name, and trait
- *   [Equal.symbol](that: Equal.Equal): boolean {
- *     if (that instanceof Character) {
- *       return (
- *         Equal.equals(this.name, that.name) &&
- *         Equal.equals(this.trait, that.trait)
- *       )
- *     }
- *     return false
- *   }
- *
- *   // Generate a hash code based on the sum of the character's name and trait
- *   [Hash.symbol](): number {
- *     throw Hash.hash(this.name + this.trait)
- *   }
- *
- *   static readonly of = (name: string, trait: string): Character => {
- *     return new Character(name, trait)
- *   }
- * }
  * ```
  *
  * @see Other `HashSet` constructors are {@link fromIterable} {@link empty}

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1,4 +1,160 @@
 /**
+ * A `HashSet` is a collection of unique values with efficient lookup, insertion
+ * and removal.
+ *
+ * ## Basic Usage
+ *
+ * HashSet solves the problem of maintaining an unsorted collection where each
+ * value appears exactly once, with fast operations for checking membership and
+ * adding/removing values.
+ *
+ * ### Value-Based Equality
+ *
+ * Unlike JavaScript's built-in {@link Set}, which checks for equality by
+ * reference, `HashSet` supports _value-based equality_ through the {@link Equal}
+ * interface. This allows objects with the same content to be treated as equal:
+ *
+ * ```ts
+ * import { HashSet, Data } from "effect"
+ *
+ * // Creating a HashSet with objects that implement the Equal interface
+ * const set = HashSet.empty().pipe(
+ *   HashSet.add(Data.struct({ name: "Alice", age: 30 })),
+ *   HashSet.add(Data.struct({ name: "Alice", age: 30 }))
+ * )
+ *
+ * // HashSet recognizes them as equal, so only one element is stored
+ * console.log(HashSet.size(set)) // Output: 1
+ * ```
+ *
+ * However, without using the Data module (or another way to implement Equal):
+ *
+ * ```ts
+ * Import { HashSet } from "effect"
+ *
+ * // Objects that do NOT implement the Equal interface const set =
+ * HashSet.empty().pipe( HashSet.add({ name: "Alice", age: 30 }), HashSet.add({name: "Alice", age: 30 }) )
+ *
+ * // Objects are compared by reference, so two elements are stored
+ * console.log(HashSet.size(set)) // Output: 2
+ * ```
+ *
+ * ## When to Use
+ *
+ * Use HashSet when you need:
+ *
+ * - A collection with no duplicate values
+ * - Efficient membership testing (O(1) average complexity)
+ * - Set operations like union, intersection, and difference
+ * - An immutable data structure that preserves functional programming patterns
+ *
+ * ## Operations Reference
+ *
+ * ### Constructors
+ *
+ * | Operation            | Description                            | Complexity |
+ * | -------------------- | -------------------------------------- | ---------- |
+ * | {@link empty}        | Creates an empty HashSet               | O(1)       |
+ * | {@link fromIterable} | Creates a HashSet from an iterable     | O(n)       |
+ * | {@link make}         | Creates a HashSet from multiple values | O(n)       |
+ *
+ * ### Elements
+ *
+ * | Operation        | Description                                 | Complexity |
+ * | ---------------- | ------------------------------------------- | ---------- |
+ * | {@link has}      | Checks if a value exists in the set         | O(1) avg   |
+ * | {@link some}     | Checks if any element satisfies a predicate | O(n)       |
+ * | {@link every}    | Checks if all elements satisfy a predicate  | O(n)       |
+ * | {@link isSubset} | Checks if a set is a subset of another      | O(n)       |
+ *
+ * ### Getters
+ *
+ * | Operation        | Description                    | Complexity |
+ * | ---------------- | ------------------------------ | ---------- |
+ * | {@link values}   | Gets an iterator of all values | O(1)       |
+ * | {@link toValues} | Gets an array of all values    | O(n)       |
+ * | {@link size}     | Gets the number of elements    | O(1)       |
+ *
+ * ### Mutations
+ *
+ * | Operation      | Description                  | Complexity |
+ * | -------------- | ---------------------------- | ---------- |
+ * | {@link add}    | Adds a value to the set      | O(1) avg   |
+ * | {@link remove} | Removes a value from the set | O(1) avg   |
+ * | {@link toggle} | Toggles a value's presence   | O(1) avg   |
+ *
+ * ### Operations
+ *
+ * | Operation            | Description                       | Complexity |
+ * | -------------------- | --------------------------------- | ---------- |
+ * | {@link difference}   | Computes set difference (A - B)   | O(n)       |
+ * | {@link intersection} | Computes set intersection (A ∩ B) | O(n)       |
+ * | {@link union}        | Computes set union (A ∪ B)        | O(n)       |
+ *
+ * ### Mapping
+ *
+ * | Operation   | Description             | Complexity |
+ * | ----------- | ----------------------- | ---------- |
+ * | {@link map} | Transforms each element | O(n)       |
+ *
+ * ### Sequencing
+ *
+ * | Operation       | Description                      | Complexity |
+ * | --------------- | -------------------------------- | ---------- |
+ * | {@link flatMap} | Transforms and flattens elements | O(n)       |
+ *
+ * ### Traversing
+ *
+ * | Operation       | Description                        | Complexity |
+ * | --------------- | ---------------------------------- | ---------- |
+ * | {@link forEach} | Applies a function to each element | O(n)       |
+ *
+ * ### Folding
+ *
+ * | Operation      | Description                       | Complexity |
+ * | -------------- | --------------------------------- | ---------- |
+ * | {@link reduce} | Reduces the set to a single value | O(n)       |
+ *
+ * ### Filtering
+ *
+ * | Operation      | Description                             | Complexity |
+ * | -------------- | --------------------------------------- | ---------- |
+ * | {@link filter} | Keeps elements that satisfy a predicate | O(n)       |
+ *
+ * ### Partitioning
+ *
+ * | Operation         | Description                         | Complexity |
+ * | ----------------- | ----------------------------------- | ---------- |
+ * | {@link partition} | Splits into two sets by a predicate | O(n)       |
+ *
+ * ## Advanced Features
+ *
+ * HashSet provides operations for:
+ *
+ * - Transforming sets with map and flatMap
+ * - Filtering elements with filter
+ * - Combining sets with union, intersection and difference
+ * - Performance optimizations via mutable operations in controlled contexts
+ *
+ * ## Performance Characteristics
+ *
+ * - Lookup operations (has): O(1) average time complexity
+ * - Insertion operations (add): O(1) average time complexity
+ * - Removal operations (remove): O(1) average time complexity
+ * - Set operations (union, intersection): O(n) where n is the size of the smaller
+ *   set
+ * - Iteration: O(n) where n is the size of the set
+ *
+ * ## Notes
+ *
+ * The HashSet data structure implements the following traits:
+ *
+ * - {@link Iterable}: allows iterating over the values in the set
+ * - {@link Equal}: allows comparing two sets for value-based equality
+ * - {@link Pipeable}: allows chaining operations with the pipe operator
+ * - {@link Inspectable}: allows inspecting the contents of the set
+ *
+ * @module
  * @since 2.0.0
  */
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -699,11 +699,72 @@ export const every: {
  *
  * **NOTE**: the hash and equal of both sets must be the same.
  *
+ * Time complexity analisys is of `O(n)`
+ *
+ * @memberof HashSet
  * @since 2.0.0
  * @category elements
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * const set1 = HashSet.make(0, 1)
+ * const set2 = HashSet.make(1, 2)
+ * const set3 = HashSet.make(0, 1, 2)
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(set1, HashSet.isSubset(set2)) // false
+ * pipe(set1, HashSet.isSubset(set3)) // true
+ *
+ * // or piped with the pipe function
+ * set1.pipe(HashSet.isSubset(set2)) // false
+ * set1.pipe(HashSet.isSubset(set3)) // true
+ *
+ * // or with `data-first` API
+ * HashSet.isSubset(set1, set2) // false
+ * HashSet.isSubset(set1, set3) // true)
+ * ```
  */
 export const isSubset: {
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * assert.equal(
+   *   pipe(
+   *     HashSet.make(0, 1), //
+   *     HashSet.isSubset(HashSet.make(1, 2))
+   *   ),
+   *   false
+   * )
+   *
+   * assert.equal(
+   *   pipe(
+   *     HashSet.make(0, 1), //
+   *     HashSet.isSubset(HashSet.make(0, 1, 2))
+   *   ),
+   *   true
+   * )
+   * ```
+   */
   <A>(that: HashSet<A>): (self: HashSet<A>) => boolean
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * assert.equal(HashSet.isSubset(set1, set2), false)
+   *
+   * assert.equal(HashSet.isSubset(set1, set3), true)
+   * ```
+   */
   <A>(self: HashSet<A>, that: HashSet<A>): boolean
 } = HS.isSubset
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -58,82 +58,40 @@
  *
  * ## Operations Reference
  *
- * ### Constructors
- *
- * | Operation            | Description                            | Complexity |
- * | -------------------- | -------------------------------------- | ---------- |
- * | {@link empty}        | Creates an empty HashSet               | O(1)       |
- * | {@link fromIterable} | Creates a HashSet from an iterable     | O(n)       |
- * | {@link make}         | Creates a HashSet from multiple values | O(n)       |
- *
- * ### Elements
- *
- * | Operation        | Description                                 | Complexity |
- * | ---------------- | ------------------------------------------- | ---------- |
- * | {@link has}      | Checks if a value exists in the set         | O(1) avg   |
- * | {@link some}     | Checks if any element satisfies a predicate | O(n)       |
- * | {@link every}    | Checks if all elements satisfy a predicate  | O(n)       |
- * | {@link isSubset} | Checks if a set is a subset of another      | O(n)       |
- *
- * ### Getters
- *
- * | Operation        | Description                    | Complexity |
- * | ---------------- | ------------------------------ | ---------- |
- * | {@link values}   | Gets an iterator of all values | O(1)       |
- * | {@link toValues} | Gets an array of all values    | O(n)       |
- * | {@link size}     | Gets the number of elements    | O(1)       |
- *
- * ### Mutations
- *
- * | Operation      | Description                  | Complexity |
- * | -------------- | ---------------------------- | ---------- |
- * | {@link add}    | Adds a value to the set      | O(1) avg   |
- * | {@link remove} | Removes a value from the set | O(1) avg   |
- * | {@link toggle} | Toggles a value's presence   | O(1) avg   |
- *
- * ### Operations
- *
- * | Operation            | Description                       | Complexity |
- * | -------------------- | --------------------------------- | ---------- |
- * | {@link difference}   | Computes set difference (A - B)   | O(n)       |
- * | {@link intersection} | Computes set intersection (A ∩ B) | O(n)       |
- * | {@link union}        | Computes set union (A ∪ B)        | O(n)       |
- *
- * ### Mapping
- *
- * | Operation   | Description             | Complexity |
- * | ----------- | ----------------------- | ---------- |
- * | {@link map} | Transforms each element | O(n)       |
- *
- * ### Sequencing
- *
- * | Operation       | Description                      | Complexity |
- * | --------------- | -------------------------------- | ---------- |
- * | {@link flatMap} | Transforms and flattens elements | O(n)       |
- *
- * ### Traversing
- *
- * | Operation       | Description                        | Complexity |
- * | --------------- | ---------------------------------- | ---------- |
- * | {@link forEach} | Applies a function to each element | O(n)       |
- *
- * ### Folding
- *
- * | Operation      | Description                       | Complexity |
- * | -------------- | --------------------------------- | ---------- |
- * | {@link reduce} | Reduces the set to a single value | O(n)       |
- *
- * ### Filtering
- *
- * | Operation      | Description                             | Complexity |
- * | -------------- | --------------------------------------- | ---------- |
- * | {@link filter} | Keeps elements that satisfy a predicate | O(n)       |
- *
- * ### Partitioning
- *
- * | Operation         | Description                         | Complexity |
- * | ----------------- | ----------------------------------- | ---------- |
- * | {@link partition} | Splits into two sets by a predicate | O(n)       |
+ * | Category     | Operation            | Description                                 | Complexity |
+ * | ------------ | -------------------- | ------------------------------------------- | ---------- |
+ * | constructors | {@link empty}        | Creates an empty HashSet                    | O(1)       |
+ * | constructors | {@link fromIterable} | Creates a HashSet from an iterable          | O(n)       |
+ * | constructors | {@link make}         | Creates a HashSet from multiple values      | O(n)       |
+ * |              |                      |                                             |            |
+ * | elements     | {@link has}          | Checks if a value exists in the set         | O(1) avg   |
+ * | elements     | {@link some}         | Checks if any element satisfies a predicate | O(n)       |
+ * | elements     | {@link every}        | Checks if all elements satisfy a predicate  | O(n)       |
+ * | elements     | {@link isSubset}     | Checks if a set is a subset of another      | O(n)       |
+ * |              |                      |                                             |            |
+ * | getters      | {@link values}       | Gets an iterator of all values              | O(1)       |
+ * | getters      | {@link toValues}     | Gets an array of all values                 | O(n)       |
+ * | getters      | {@link size}         | Gets the number of elements                 | O(1)       |
+ * |              |                      |                                             |            |
+ * | mutations    | {@link add}          | Adds a value to the set                     | O(1) avg   |
+ * | mutations    | {@link remove}       | Removes a value from the set                | O(1) avg   |
+ * | mutations    | {@link toggle}       | Toggles a value's presence                  | O(1) avg   |
+ * |              |                      |                                             |            |
+ * | operations   | {@link difference}   | Computes set difference (A - B)             | O(n)       |
+ * | operations   | {@link intersection} | Computes set intersection (A ∩ B)           | O(n)       |
+ * | operations   | {@link union}        | Computes set union (A ∪ B)                  | O(n)       |
+ * |              |                      |                                             |            |
+ * | mapping      | {@link map}          | Transforms each element                     | O(n)       |
+ * |              |                      |                                             |            |
+ * | sequencing   | {@link flatMap}      | Transforms and flattens elements            | O(n)       |
+ * |              |                      |                                             |            |
+ * | traversing   | {@link forEach}      | Applies a function to each element          | O(n)       |
+ * |              |                      |                                             |            |
+ * | folding      | {@link reduce}       | Reduces the set to a single value           | O(n)       |
+ * |              |                      |                                             |            |
+ * | filtering    | {@link filter}       | Keeps elements that satisfy a predicate     | O(n)       |
+ * |              |                      |                                             |            |
+ * | partitioning | {@link partition}    | Splits into two sets by a predicate         | O(n)       |
  *
  * ## Advanced Features
  *

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -500,6 +500,21 @@ export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(sel
  *
  * @since 2.0.0
  * @category getters
+ * @example
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ * import assert from "node:assert/strict"
+ *
+ * assert.deepStrictEqual(pipe(HashSet.empty(), HashSet.size), 0)
+ *
+ * assert.deepStrictEqual(
+ *   pipe(HashSet.make(1, 2, 2, 3, 4, 3), HashSet.size),
+ *   4
+ * )
+ * ```
+ *
+ * @see check out the other gettes {@link values} {@link toValues}
  */
 export const size: <A>(self: HashSet<A>) => number = HS.size
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -429,7 +429,7 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
  *
  *   // Generate a hash code based on the sum of the character's name and trait
  *   [Hash.symbol](): number {
- *     throw Hash.hash(this.name + this.trait)
+ *     return Hash.hash(this.name + this.trait)
  *   }
  *
  *   static readonly of = (name: string, trait: string): Character => {
@@ -1019,7 +1019,7 @@ export const add: {
    *
    * assert.deepStrictEqual(HashSet.toValues(withTwoTwo), Array.of(0, 1, 2))
    * ```
-   */ 
+   */
   <A>(self: HashSet<A>, value: A): HashSet<A>
 } = HS.add
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -233,6 +233,80 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
  *
  * @since 2.0.0
  * @category constructors
+ * @example
+ *   import { Equal, Hash, HashSet, pipe } from "effect"
+ *   import assert from "node:assert/strict"
+ *
+ *   assert.strictEqual(
+ *     Equal.equals(
+ *       HashSet.make(
+ *         Character.of("Alice", "Curious"),
+ *         Character.of("Alice", "Curious"),
+ *         Character.of("White Rabbit", "Always late"),
+ *         Character.of("Mad Hatter", "Tea enthusiast")
+ *       ),
+ *       // Is the same as adding each character to an empty set
+ *       pipe(
+ *         HashSet.empty(),
+ *         HashSet.add(Character.of("Alice", "Curious")),
+ *         HashSet.add(Character.of("Alice", "Curious")), // Alice tried to attend twice!
+ *         HashSet.add(Character.of("White Rabbit", "Always late")),
+ *         HashSet.add(Character.of("Mad Hatter", "Tea enthusiast"))
+ *       )
+ *     ),
+ *     true
+ *   )
+ *
+ *   assert.strictEqual(
+ *     Equal.equals(
+ *       HashSet.make(
+ *         Character.of("Alice", "Curious"),
+ *         Character.of("Alice", "Curious"),
+ *         Character.of("White Rabbit", "Always late"),
+ *         Character.of("Mad Hatter", "Tea enthusiast")
+ *       ),
+ *       // Is the same as creating a set from an iterable
+ *       HashSet.fromIterable([
+ *         Character.of("Alice", "Curious"),
+ *         Character.of("Alice", "Curious"),
+ *         Character.of("White Rabbit", "Always late"),
+ *         Character.of("Mad Hatter", "Tea enthusiast")
+ *       ])
+ *     ),
+ *     true
+ *   )
+ *
+ *   class Character implements Equal.Equal {
+ *     readonly name: string
+ *     readonly trait: string
+ *
+ *     constructor(name: string, trait: string) {
+ *       this.name = name
+ *       this.trait = trait
+ *     }
+ *
+ *     // Define equality based on name, and trait
+ *     [Equal.symbol](that: Equal.Equal): boolean {
+ *       if (that instanceof Character) {
+ *         return (
+ *           Equal.equals(this.name, that.name) &&
+ *           Equal.equals(this.trait, that.trait)
+ *         )
+ *       }
+ *       return false
+ *     }
+ *
+ *     // Generate a hash code based on the sum of the character's name and trait
+ *     [Hash.symbol](): number {
+ *       throw Hash.hash(this.name + this.trait)
+ *     }
+ *
+ *     static readonly of = (name: string, trait: string): Character => {
+ *       return new Character(name, trait)
+ *     }
+ *   }
+ *
+ * @see Other `HashSet` constructors are {@link fromIterable} {@link empty}
  */
 export const make: <As extends ReadonlyArray<any>>(...elements: As) => HashSet<As[number]> = HS.make
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1,9 +1,49 @@
 /**
- * An immutable `HashSet` provides a collection of unique values. Once created,
- * a `HashSet` cannot be modified; any operation that would alter the set
- * instead returns a new `HashSet` with the changes. This immutability offers
- * benefits like predictable state management and easier reasoning about your
- * code.
+ * An immutable `HashSet` provides a collection of unique values with efficient
+ * lookup, insertion and removal. Once created, a `HashSet` cannot be modified;
+ * any operation that would alter the set instead returns a new `HashSet` with
+ * the changes. This immutability offers benefits like predictable state
+ * management and easier reasoning about your code.
+ *
+ * ## What Problem Does It Solve?
+ *
+ * `HashSet` solves the problem of maintaining an unsorted collection where each
+ * value appears exactly once, with fast operations for checking membership and
+ * adding/removing values.
+ *
+ * ## When to Use
+ *
+ * Use `HashSet` when you need:
+ *
+ * - A collection with no duplicate values
+ * - Efficient membership testing (O(1) average complexity)
+ * - Set operations like union, intersection, and difference
+ * - An immutable data structure that preserves functional programming patterns
+ *
+ * ## Advanced Features
+ *
+ * HashSet provides operations for:
+ *
+ * - Transforming sets with map and flatMap
+ * - Filtering elements with filter
+ * - Combining sets with union, intersection and difference
+ * - Performance optimizations via mutable operations in controlled contexts
+ *
+ * ## Performance Characteristics
+ *
+ * - **Lookup** operations ({@link has}): **O(1)** average time complexity
+ * - **Insertion** operations ({@link add}): **O(1)** average time complexity
+ * - **Removal** operations ({@link remove}): **O(1)** average time complexity
+ * - **Set** operations ({@link union}, {@link intersection}): **O(n)** where n is
+ *   the size of the smaller set
+ * - **Iteration**: **O(n)** where n is the size of the set
+ *
+ * The HashSet data structure implements the following traits:
+ *
+ * - {@link Iterable}: allows iterating over the values in the set
+ * - {@link Equal}: allows comparing two sets for value-based equality
+ * - {@link Pipeable}: allows chaining operations with the pipe operator
+ * - {@link Inspectable}: allows inspecting the contents of the set
  *
  * ## Operations Reference
  *
@@ -44,16 +84,7 @@
  *
  * ## Notes
  *
- * **Immutability for Beginners:**
- *
- * When you perform an operation that seems like it should modify the `HashSet`
- * (like {@link add `HashSet.add`} or {@link remove `HashSet.remove`}), it doesn't
- * change the original set. Instead, it creates and returns a _new_ `HashSet`
- * with the updated elements. This makes your code more predictable.
- *
- * ### Interoperability:
- *
- * #### With the Effect Library:
+ * ### Composability with the Effect Ecosystem:
  *
  * This `HashSet` is designed to work seamlessly within the Effect ecosystem. It
  * implements the {@link Iterable}, {@link Equal}, {@link Pipeable}, and
@@ -184,7 +215,7 @@
  * console.log(HashSet.size(set)) // Output: 1
  * ```
  *
- * #### With the JavaScript Runtime:
+ * ### Interoperability with the JavaScript Runtime:
  *
  * To interoperate with the regular JavaScript runtime, Effect's `HashSet`
  * provides methods to access its elements in formats readily usable by
@@ -207,12 +238,9 @@
  * console.log(array) // Logs: [ 1, 2, 3 ]
  * ```
  *
- * The HashSet data structure implements the following traits:
- *
- * - {@link Iterable}: allows iterating over the values in the set
- * - {@link Equal}: allows comparing two sets for value-based equality
- * - {@link Pipeable}: allows chaining operations with the pipe operator
- * - {@link Inspectable}: allows inspecting the contents of the set
+ * Be mindful of performance implications (both time and space complexity) when
+ * frequently converting between Effect's immutable HashSet and mutable
+ * JavaScript data structures, especially for large collections.
  *
  * @module HashSet
  * @since 2.0.0

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -545,12 +545,34 @@ export const mutate: {
 /**
  * Adds a value to the `HashSet`.
  *
+ * @remarks
+ * Remember that a `HashSet` is a collection of unique values, so adding a value
+ * that already exists in the `HashSet` will not add a duplicate.
+ *
+ * Remember that HashSet is an immutable data structure, so the `add` function,
+ * like all other functions that modify the HashSet, will return a new HashSet
+ * with the added value.
  * @since 2.0.0
- * @see check out the other mutaitons {@link remove} {@link toggle}
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with data-last, a.k.a. pipeable API
+ * pipe(HashSet.empty(), HashSet.add(0), HashSet.add(0))
+ *
+ * // or piped with the pipe function
+ * HashSet.empty().pipe(HashSet.add(0))
+ *
+ * // or with data-first API
+ * HashSet.add(HashSet.empty(), 0)
+ * ```
+ *
+ * @see check out the other mutations {@link remove} {@link toggle}
  */
 export const add: {
   /**
-   * @example Add pipable api
+   * @example {@link add} `data-last` a.k.a. `pipeable` API
    *
    * ```ts
    * import { HashSet, pipe } from "effect"
@@ -572,7 +594,7 @@ export const add: {
   <A>(value: A): (self: HashSet<A>) => HashSet<A>
 
   /**
-   * @example
+   * @example {@link add} `data-first` API
    *
    * ```ts
    * import { HashSet, pipe } from "effect"

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -228,6 +228,51 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
  *
  * @since 2.0.0
  * @category constructors
+ * @example Creating a HashSet from an {@link Array}
+ *
+ * ```ts
+ * import { HashSet } from "effect"
+ *
+ * const array: Iterable<number> = [1, 2, 3, 4, 5, 1, 2, 3] // Note the duplicates
+ * const uniqueNumbers = HashSet.fromIterable(array)
+ *
+ * console.log(HashSet.toValues(uniqueNumbers)) // Output: [1, 2, 3, 4, 5]
+ * ```
+ *
+ * @example Creating a HashSet from a {@link Set}
+ *
+ * ```ts
+ * import { HashSet } from "effect"
+ *
+ * const fruitsSet: Iterable<string> = new Set([
+ *   "apple",
+ *   "banana",
+ *   "orange",
+ *   "apple"
+ * ])
+ * const fruitsHashSet = HashSet.fromIterable(fruitsSet)
+ *
+ * console.log(HashSet.toValues(fruitsHashSet)) // Output: ["apple", "banana", "orange"]
+ * ```
+ *
+ * @example Creating a HashSet from a {@link Generator}
+ *
+ * ```ts
+ * // Generator functions return iterables
+ * function* fibonacci(n: number): Generator<number, void, unknown> {
+ *   let [a, b] = [0, 1]
+ *   for (let i = 0; i < n; i++) {
+ *     yield a
+ *     ;[a, b] = [b, a + b]
+ *   }
+ * }
+ *
+ * // Create a HashSet from the first 10 Fibonacci numbers
+ * const fibonacciSet = HashSet.fromIterable(fibonacci(10))
+ *
+ * console.log(HashSet.toValues(fibonacciSet))
+ * // Outputs: [0, 1, 2, 3, 5, 8, 13, 21, 34] but in unsorted order
+ * ```
  */
 export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIterable
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -15,10 +15,14 @@
  * interface. This allows objects with the same content to be treated as equal:
  *
  * ```ts
- * import { HashSet, Data } from "effect"
+ * import { Data, HashSet, pipe } from "effect"
  *
  * // Creating a HashSet with objects that implement the Equal interface
- * const set = HashSet.empty().pipe(
+ * const set: HashSet.HashSet<{
+ *   readonly age: number
+ *   readonly name: string
+ * }> = pipe(
+ *   HashSet.empty(),
  *   HashSet.add(Data.struct({ name: "Alice", age: 30 })),
  *   HashSet.add(Data.struct({ name: "Alice", age: 30 }))
  * )
@@ -30,10 +34,14 @@
  * However, without using the Data module (or another way to implement Equal):
  *
  * ```ts
- * Import { HashSet } from "effect"
+ * import { HashSet, pipe } from "effect"
  *
  * // Objects that do NOT implement the Equal interface const set =
- * HashSet.empty().pipe( HashSet.add({ name: "Alice", age: 30 }), HashSet.add({name: "Alice", age: 30 }) )
+ * const set = pipe(
+ *   HashSet.empty(),
+ *   HashSet.add({ name: "Alice", age: 30 }),
+ *   HashSet.add({ name: "Alice", age: 30 })
+ * )
  *
  * // Objects are compared by reference, so two elements are stored
  * console.log(HashSet.size(set)) // Output: 2
@@ -195,6 +203,20 @@ export const isHashSet: {
  *
  * @since 2.0.0
  * @category constructors
+ * @example
+ *   import { HashSet } from "effect"
+ *
+ *   // Provide a type argument to create a HashSet of a specific type
+ *   const emptyHashSetOfNumbers = HashSet.empty<number>()
+ *
+ *   emptyHashSetOfNumbers.pipe(
+ *     HashSet.add(1),
+ *     HashSet.add(1),
+ *     HashSet.add(2)
+ *   )
+ *
+ *   console.log(HashSet.size(emptyHashSetOfNumbers)) // Output: 2
+ *   console.log(HashSet.toValues(emptyHashSetOfNumbers)) // Output: [1, 2]
  */
 export const empty: <A = never>() => HashSet<A> = HS.empty
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -448,6 +448,22 @@ export const isSubset: {
  *
  * @since 2.0.0
  * @category getters
+ * @example
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * const numberIterable = pipe(
+ *   HashSet.make(0, 1, 1, 2), // HashSet.HashSet<number>
+ *   HashSet.values // takes an HashSet<A> and returns an IterableIterator<A>
+ * )
+ *
+ * for (const number of numberIterable) {
+ *   console.log(number) // it will logs: 0, 1, 2
+ * }
+ * ```
+ *
+ * @see check out the other gettes {@link toValues} {@link size}
  */
 export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -204,19 +204,20 @@ export const isHashSet: {
  * @since 2.0.0
  * @category constructors
  * @example
- *   import { HashSet } from "effect"
  *
- *   // Provide a type argument to create a HashSet of a specific type
- *   const emptyHashSetOfNumbers = HashSet.empty<number>()
+ * ```ts
+ * import { HashSet } from "effect"
  *
- *   emptyHashSetOfNumbers.pipe(
- *     HashSet.add(1),
- *     HashSet.add(1),
- *     HashSet.add(2)
- *   )
+ * // Provide a type argument to create a HashSet of a specific type
+ * const emptyHashSetOfNumbers = HashSet.empty<number>().pipe(
+ *   HashSet.add(1),
+ *   HashSet.add(1),
+ *   HashSet.add(2)
+ * )
  *
- *   console.log(HashSet.size(emptyHashSetOfNumbers)) // Output: 2
- *   console.log(HashSet.toValues(emptyHashSetOfNumbers)) // Output: [1, 2]
+ * console.log(HashSet.size(emptyHashSetOfNumbers)) // Output: 2
+ * console.log(HashSet.toValues(emptyHashSetOfNumbers)) // Output: [1, 2]
+ * ```
  */
 export const empty: <A = never>() => HashSet<A> = HS.empty
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1394,13 +1394,150 @@ export const reduce: {
 /**
  * Filters values out of a `HashSet` using the specified predicate.
  *
+ * The time complexity is of **`O(n)`**.
+ *
+ * @memberof HashSet
  * @since 2.0.0
  * @category filtering
+ * @example **Syntax** with {@link Predicate}
+ *
+ * ```ts
+ * import { HashSet, type Predicate, pipe } from "effect"
+ *
+ * const filterPositiveNumbers: Predicate.Predicate<number> = (n) => n > 0
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(
+ *   HashSet.make(-2, -1, 0, 1, 2),
+ *   HashSet.filter(filterPositiveNumbers)
+ * )
+ *
+ * // or with the pipe method
+ * HashSet.make(-2, -1, 0, 1, 2).pipe(HashSet.filter(filterPositiveNumbers))
+ *
+ * // or with `data-first` API
+ * HashSet.filter(HashSet.make(-2, -1, 0, 1, 2), filterPositiveNumbers)
+ * ```
+ *
+ * @example **Syntax** with {@link Refinement}
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * const stringRefinement = (value: unknown): value is string =>
+ *   typeof value === "string"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(
+ *   HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier"), // // HashSet.HashSet<number | string>
+ *   HashSet.filter(stringRefinement)
+ * ) // HashSet.HashSet<string>
+ *
+ * // or with the pipe method
+ * HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier") // HashSet.HashSet<number | string>
+ *   .pipe(HashSet.filter(stringRefinement)) // HashSet.HashSet<string>
+ *
+ * // or with `data-first` API
+ * HashSet.filter(
+ *   HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier"), // HashSet.HashSet<number | string>
+ *   stringRefinement
+ * ) // HashSet.HashSet<string>
+ * ```
  */
 export const filter: {
-  <A, B extends A>(refinement: Refinement<NoInfer<A>, B>): (self: HashSet<A>) => HashSet<B>
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe, Predicate } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const numbersAndStringsHashSet: HashSet.HashSet<number | string> =
+   *   HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier")
+   *
+   * const stringRefinement: Predicate.Refinement<
+   *   string | number,
+   *   string
+   * > = (value) => typeof value === "string"
+   *
+   * const stringHashSet: HashSet.HashSet<string> = pipe(
+   *   numbersAndStringsHashSet,
+   *   HashSet.filter(stringRefinement)
+   * )
+   *
+   * assert.equal(
+   *   pipe(stringHashSet, HashSet.every(Predicate.isString)),
+   *   true
+   * )
+   * ```
+   */
+  <A, B extends A>(
+    refinement: Refinement<NoInfer<A>, B>
+  ): (self: HashSet<A>) => HashSet<B>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe, type Predicate } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const filterPositiveNumbers: Predicate.Predicate<number> = (n) => n > 0
+   *
+   * assert.deepStrictEqual(
+   *   pipe(
+   *     HashSet.make(-2, -1, 0, 1, 2),
+   *     HashSet.filter(filterPositiveNumbers)
+   *   ),
+   *   HashSet.make(1, 2)
+   * )
+   * ```
+   */
   <A>(predicate: Predicate<NoInfer<A>>): (self: HashSet<A>) => HashSet<A>
-  <A, B extends A>(self: HashSet<A>, refinement: Refinement<A, B>): HashSet<B>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, Predicate } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const numbersAndStringsHashSet: HashSet.HashSet<number | string> =
+   *   HashSet.make(1, "unos", 2, "two", 3, "trois", 4, "vier")
+   *
+   * const stringRefinement: Predicate.Refinement<
+   *   string | number,
+   *   string
+   * > = (value) => typeof value === "string"
+   *
+   * const stringHashSet: HashSet.HashSet<string> = HashSet.filter(
+   *   numbersAndStringsHashSet,
+   *   stringRefinement
+   * )
+   *
+   * assert.equal(HashSet.every(stringHashSet, Predicate.isString), true)
+   * ```
+   */
+  <A, B extends A>(
+    self: HashSet<A>,
+    refinement: Refinement<A, B>
+  ): HashSet<B>
+
+  /**
+   * @example
+   *
+   * ```ts
+   * import { HashSet, pipe, type Predicate } from "effect"
+   * import * as assert from "node:assert/strict"
+   *
+   * const filterPositiveNumbers: Predicate.Predicate<number> = (n) => n > 0
+   *
+   * assert.deepStrictEqual(
+   *   HashSet.filter(HashSet.make(-2, -1, 0, 1, 2), filterPositiveNumbers),
+   *   HashSet.make(1, 2)
+   * )
+   * ```
+   */
   <A>(self: HashSet<A>, predicate: Predicate<A>): HashSet<A>
 } = HS.filter
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -406,11 +406,60 @@ export const make: <As extends ReadonlyArray<any>>(...elements: As) => HashSet<A
 /**
  * Checks if the specified value exists in the `HashSet`.
  *
+ * @memberof HashSet
  * @since 2.0.0
  * @category elements
+ * @example **syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(HashSet.make(0, 1, 2), HashSet.has(3)) // false
+ *
+ * // or piped with the pipe function
+ * HashSet.make(0, 1, 2).pipe(HashSet.has(3)) // false
+ *
+ * // or with `data-first` API
+ * HashSet.has(HashSet.make(0, 1, 2), 3) // false
+ * ```
+ *
+ * @returns A `boolean` signaling the presence of the value in the HashSet
+ * @todo Add time complexity analisys
  */
 export const has: {
+  /**
+   * @example {@link has} `data-last` a.k.a. `pipeable` API
+   *
+   * ```ts
+   * import * as assert from "node:assert/strict"
+   * import { HashSet, pipe } from "effect"
+   *
+   * const set = HashSet.make(0, 1, 2)
+   *
+   * assert.equal(pipe(set, HashSet.has(0)), true)
+   * assert.equal(pipe(set, HashSet.has(1)), true)
+   * assert.equal(pipe(set, HashSet.has(2)), true)
+   * assert.equal(pipe(set, HashSet.has(3)), false)
+   * ```
+   */
   <A>(value: A): (self: HashSet<A>) => boolean
+
+  /**
+   * @example {@link has} `data-first` API
+   *
+   * ```ts
+   * import * as assert from "node:assert/strict"
+   * import { HashSet, pipe } from "effect"
+   *
+   * const set = HashSet.make(0, 1, 2)
+   *
+   * assert.equal(HashSet.has(set, 0), true)
+   * assert.equal(HashSet.has(set, 1), true)
+   * assert.equal(HashSet.has(set, 2), true)
+   * assert.equal(HashSet.has(set, 3), false)
+   * ```
+   */
   <A>(self: HashSet<A>, value: A): boolean
 } = HS.has
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -990,10 +990,49 @@ export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(sel
 export const size: <A>(self: HashSet<A>) => number = HS.size
 
 /**
- * Marks the `HashSet` as mutable.
+ * Creates a new mutable version of the `HashSet`
+ *
+ * When a `HashSet` is mutable, operations like {@link add} and {@link remove}
+ * modify the data structure in place instead of creating a new one, which is
+ * more efficient when performing multiple operations.
  *
  * @memberof HashSet
  * @since 2.0.0
+ * @example
+ *
+ * ```ts
+ * import { HashSet } from "effect"
+ * import assert from "node:assert/strict"
+ *
+ * const UPPER_BOUND = 10_000
+ *
+ * const immutableSet = HashSet.empty<number>().pipe(HashSet.add(0))
+ *
+ * // Create a mutable version of the immutableSet
+ * const mutableSet = HashSet.beginMutation(immutableSet)
+ *
+ * for (let i = 1; i < UPPER_BOUND; i++) {
+ *   // Operations now modify the set in place instead of creating new instances
+ *   // This is more efficient when making multiple changes
+ *   const pointerToMutableSet = HashSet.add(mutableSet, i)
+ *
+ *   // the two sets have the same identity, hence `add` is mutating mutableSet and not returning a new HashSet instance
+ *   assert(Object.is(mutableSet, pointerToMutableSet))
+ *   assert.equal(HashSet.has(mutableSet, i), true) // `i` is in the mutableSet
+ *   assert.equal(HashSet.has(immutableSet, i), false) // `i` is not in the immutableSet
+ * }
+ *
+ * const next = UPPER_BOUND + 1
+ * // When done, mark the set as immutable again
+ * HashSet.endMutation(mutableSet).pipe(
+ *   HashSet.add(next) // since this returns a new HashSet, it will not be logged as part of the mutableSet
+ * )
+ * assert.equal(HashSet.has(mutableSet, next), false)
+ *
+ * console.log(HashSet.toValues(immutableSet)) // [0]
+ * console.log(HashSet.toValues(mutableSet).sort((a, b) => a - b)) // [0, 1, 2, 3, ...rest]
+ * ```
+ *
  * @see Other `HashSet` mutations are {@link add} {@link remove} {@link toggle} {@link endMutation} {@link mutate}
  */
 export const beginMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.beginMutation

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -206,17 +206,18 @@ export const isHashSet: {
  * @example
  *
  * ```ts
- * import { HashSet } from "effect"
+ * import { HashSet, pipe } from "effect"
  *
- * // Provide a type argument to create a HashSet of a specific type
- * const emptyHashSetOfNumbers = HashSet.empty<number>().pipe(
- *   HashSet.add(1),
- *   HashSet.add(1),
- *   HashSet.add(2)
- * )
- *
- * console.log(HashSet.size(emptyHashSetOfNumbers)) // Output: 2
- * console.log(HashSet.toValues(emptyHashSetOfNumbers)) // Output: [1, 2]
+ * console.log(
+ *   pipe(
+ *     // Provide a type argument to create a HashSet of a specific type
+ *     HashSet.empty<number>(),
+ *     HashSet.add(1),
+ *     HashSet.add(1), // Notice the duplicate
+ *     HashSet.add(2),
+ *     HashSet.toValues
+ *   )
+ * ) // Output: [1, 2]
  * ```
  *
  * @see Other `HashSet` constructors are {@link make} {@link fromIterable}

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -470,8 +470,26 @@ export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
 /**
  * Returns an `Array` of the values within the `HashSet`.
  *
+ * Time complexity of O(n)
+ *
  * @since 3.13.0
  * @category getters
+ * @example
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ * import { deepStrictEqual } from "node:assert/strict"
+ *
+ * deepStrictEqual(
+ *   pipe(
+ *     HashSet.make(0, 1, 1, 2), // HashSet<number>
+ *     HashSet.toValues // takes an HashSet<A> and returns an Array<A>
+ *   ),
+ *   Array.of(0, 1, 2)
+ * )
+ * ```
+ *
+ * @see check out the other gettes {@link values} {@link size}
  */
 export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(self))
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -218,6 +218,8 @@ export const isHashSet: {
  * console.log(HashSet.size(emptyHashSetOfNumbers)) // Output: 2
  * console.log(HashSet.toValues(emptyHashSetOfNumbers)) // Output: [1, 2]
  * ```
+ *
+ * @see Other `HashSet` constructors are {@link make} {@link fromIterable}
  */
 export const empty: <A = never>() => HashSet<A> = HS.empty
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -728,10 +728,84 @@ export const union: {
  * will be removed from the `HashSet`, otherwise the value will be added to the
  * `HashSet`.
  *
+ * @memberof HashSet
  * @since 2.0.0
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with `data-last`, a.k.a. `pipeable` API
+ * pipe(HashSet.make(0, 1, 2), HashSet.toggle(0))
+ *
+ * // or piped with the pipe function
+ * HashSet.make(0, 1, 2).pipe(HashSet.toggle(0))
+ *
+ * // or with `data-first` API
+ * HashSet.toggle(HashSet.make(0, 1, 2), 0)
+ * ```
+ *
+ * @returns A new `HashSet` where the toggled value is being either added or
+ *   removed based on the initial `HashSet` state.
+ * @todo Add time space complexity analisys
+ *
+ * @todo Remember to point out that HasSet is an immutable data structure
  */
 export const toggle: {
+  /**
+   * @example {@link toggle} `data-last` a.k.a. `pipeable` API
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import assert from "node:assert/strict"
+   *
+   * // arrange
+   * let set = HashSet.make(0, 1, 2)
+   *
+   * // assert 1: 0 is in the set
+   * assert.equal(pipe(set, HashSet.has(0)), true)
+   *
+   * // act 2: toggle 0 once on the set
+   * set = pipe(set, HashSet.toggle(0))
+   *
+   * // assert 2: 0 is not in the set any longer
+   * assert.equal(pipe(set, HashSet.has(0)), false)
+   *
+   * // act 3: toggle 0 once again on the set
+   * set = pipe(set, HashSet.toggle(0))
+   *
+   * // assert 3: 0 in now back in the set
+   * assert.equal(pipe(set, HashSet.has(0)), true)
+   * ```
+   */
   <A>(value: A): (self: HashSet<A>) => HashSet<A>
+
+  /**
+   * @example {@link toggle} `data-first` API
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import assert from "node:assert/strict"
+   *
+   * // arrange
+   * let set = HashSet.make(0, 1, 2)
+   *
+   * // assert 1: 0 is in the set
+   * assert.equal(HashSet.has(set, 0), true)
+   *
+   * // act 2: toggle 0 once on the set
+   * set = HashSet.toggle(set, 0)
+   *
+   * // assert 2: 0 is not in the set any longer
+   * assert.equal(HashSet.has(set, 0), false)
+   *
+   * // act 3: toggle 0 once again on the set
+   * set = HashSet.toggle(set, 0)
+   *
+   * // assert 3: 0 in now back in the set
+   * assert.equal(HashSet.has(set, 0), true)
+   * ```
+   */
   <A>(self: HashSet<A>, value: A): HashSet<A>
 } = HS.toggle
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -162,7 +162,7 @@
  * - {@link Pipeable}: allows chaining operations with the pipe operator
  * - {@link Inspectable}: allows inspecting the contents of the set
  *
- * @module
+ * @module HashSet
  * @since 2.0.0
  */
 

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1117,13 +1117,10 @@ export const endMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.endMutation
  * )
  *
  * // or with data-first API
- * HashSet.mutate(
- *   HashSet.make(1, 2, 3),
- *   (set) => {
- *     HashSet.add(set, 4)
- *     HashSet.remove(set, 1)
- *   }
- * )
+ * HashSet.mutate(HashSet.make(1, 2, 3), (set) => {
+ *   HashSet.add(set, 4)
+ *   HashSet.remove(set, 1)
+ * })
  * ```
  *
  * @see Other `HashSet` mutations are {@link add} {@link remove} {@link toggle} {@link beginMutation} {@link endMutation}
@@ -1154,7 +1151,10 @@ export const mutate: {
    *
    * // The original set is unchanged
    * assert.equal(Object.is(immutableSet, result), false)
-   * assert.deepStrictEqual(HashSet.toValues(immutableSet).sort(), [1, 2, 3])
+   * assert.deepStrictEqual(
+   *   HashSet.toValues(immutableSet).sort(),
+   *   [1, 2, 3]
+   * )
    *
    * // The result contains the mutations
    * assert.deepStrictEqual(HashSet.toValues(result).sort(), [2, 3, 4])
@@ -1181,7 +1181,10 @@ export const mutate: {
    *
    * // The original set is unchanged
    * assert.equal(Object.is(immutableSet, result), false)
-   * assert.deepStrictEqual(HashSet.toValues(immutableSet).sort(), [1, 2, 3])
+   * assert.deepStrictEqual(
+   *   HashSet.toValues(immutableSet).sort(),
+   *   [1, 2, 3]
+   * )
    *
    * // The result contains the mutations
    * assert.deepStrictEqual(HashSet.toValues(result).sort(), [2, 3, 4])

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -302,7 +302,7 @@ export const isHashSet: {
  * ```
  *
  * @see Other `HashSet` constructors are {@link make} {@link fromIterable}
- * @todo Remember to add time complexity analisys
+ * @todo Remember to add time complexity analysis
  */
 export const empty: <A = never>() => HashSet<A> = HS.empty
 
@@ -391,7 +391,7 @@ export const empty: <A = never>() => HashSet<A> = HS.empty
  * ) // Outputs: [1, 2, 3, 4]
  * ```
  *
- * @todo Remember to add time complexity analisys
+ * @todo Remember to add time complexity analysis
  */
 export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIterable
 
@@ -479,7 +479,7 @@ export const fromIterable: <A>(elements: Iterable<A>) => HashSet<A> = HS.fromIte
  * ```
  *
  * @see Other `HashSet` constructors are {@link fromIterable} {@link empty}
- * @todo Remember to add time complexity analisys
+ * @todo Remember to add time complexity analysis
  */
 export const make: <As extends ReadonlyArray<any>>(...elements: As) => HashSet<As[number]> = HS.make
 
@@ -505,7 +505,7 @@ export const make: <As extends ReadonlyArray<any>>(...elements: As) => HashSet<A
  * ```
  *
  * @returns A `boolean` signaling the presence of the value in the HashSet
- * @todo Add time complexity analisys
+ * @todo Add time complexity analysis
  */
 export const has: {
   /**
@@ -569,7 +569,7 @@ export const has: {
  * HashSet.some(set, (n) => n > 0) // true
  * ```
  *
- * @todo Add time complexity analisys
+ * @todo Add time complexity analysis
  */
 export const some: {
   /**
@@ -676,7 +676,7 @@ export const some: {
  * HashSet.every(set, (n) => n >= 0) // true
  * ```
  *
- * @returns A boolean once it has evaluated that whole collecion fullfill the
+ * @returns A boolean once it has evaluated that whole collection fulfill the
  *   Predicate function
  */
 export const every: {
@@ -779,7 +779,7 @@ export const every: {
  *
  * **NOTE**: the hash and equal of both sets must be the same.
  *
- * Time complexity analisys is of `O(n)`
+ * Time complexity analysis is of `O(n)`
  *
  * @memberof HashSet
  * @since 2.0.0
@@ -869,8 +869,8 @@ export const isSubset: {
  * }
  * ```
  *
- * @see check out the other gettes {@link toValues} {@link size}
- * @todo Remember to add time complexity analisys
+ * @see check out the other getters {@link toValues} {@link size}
+ * @todo Remember to add time complexity analysis
  */
 export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
 
@@ -897,8 +897,8 @@ export const values: <A>(self: HashSet<A>) => IterableIterator<A> = HS.values
  * )
  * ```
  *
- * @see check out the other gettes {@link values} {@link size}
- * @todo Remember to add time complexity analisys
+ * @see check out the other getters {@link values} {@link size}
+ * @todo Remember to add time complexity analysis
  */
 export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(self))
 
@@ -922,8 +922,8 @@ export const toValues = <A>(self: HashSet<A>): Array<A> => Array.from(values(sel
  * )
  * ```
  *
- * @see check out the other gettes {@link values} {@link toValues}
- * @todo Remember to add time complexity analisys
+ * @see check out the other getters {@link values} {@link toValues}
+ * @todo Remember to add time complexity analysis
  */
 export const size: <A>(self: HashSet<A>) => number = HS.size
 
@@ -979,7 +979,7 @@ export const mutate: {
  * ```
  *
  * @see check out the other mutations {@link remove} {@link toggle}
- * @todo Remember to add time complexity analisys
+ * @todo Remember to add time complexity analysis
  */
 export const add: {
   /**
@@ -1043,9 +1043,9 @@ export const add: {
  * HashSet.remove(HashSet.make(0, 1, 2), 0)
  * ```
  *
- * @todo Remind the user of the immutability garanties of the HashSet data type
+ * @todo Remind the user of the immutability guaranties of the HashSet data type
  *
- * @todo Add time complexity analisys
+ * @todo Add time complexity analysis
  */
 export const remove: {
   /**
@@ -1151,7 +1151,7 @@ export const union: {
  *
  * @returns A new `HashSet` where the toggled value is being either added or
  *   removed based on the initial `HashSet` state.
- * @todo Add time space complexity analisys
+ * @todo Add time space complexity analysis
  *
  * @todo Remember to point out that HasSet is an immutable data structure
  */

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -1088,12 +1088,105 @@ export const endMutation: <A>(self: HashSet<A>) => HashSet<A> = HS.endMutation
 /**
  * Mutates the `HashSet` within the context of the provided function.
  *
+ * You can consider it a functional abstraction on top of the lower-level
+ * mutation primitives of {@linkcode beginMutation} `->` `mutable context` `->`
+ * {@linkcode endMutation}.
+ *
  * @memberof HashSet
  * @since 2.0.0
+ * @example **Syntax**
+ *
+ * ```ts
+ * import { HashSet, pipe } from "effect"
+ *
+ * // with data-last, a.k.a. pipeable API
+ * pipe(
+ *   HashSet.make(1, 2, 3),
+ *   HashSet.mutate((set) => {
+ *     HashSet.add(set, 4)
+ *     HashSet.remove(set, 1)
+ *   })
+ * )
+ *
+ * // or piped with the pipe function
+ * HashSet.make(1, 2, 3).pipe(
+ *   HashSet.mutate((set) => {
+ *     HashSet.add(set, 4)
+ *     HashSet.remove(set, 1)
+ *   })
+ * )
+ *
+ * // or with data-first API
+ * HashSet.mutate(
+ *   HashSet.make(1, 2, 3),
+ *   (set) => {
+ *     HashSet.add(set, 4)
+ *     HashSet.remove(set, 1)
+ *   }
+ * )
+ * ```
+ *
  * @see Other `HashSet` mutations are {@link add} {@link remove} {@link toggle} {@link beginMutation} {@link endMutation}
  */
 export const mutate: {
+  /**
+   * @example {@link mutate} `data-last` a.k.a. `pipeable` API
+   *
+   * ```ts
+   * import { HashSet, pipe } from "effect"
+   * import assert from "node:assert/strict"
+   *
+   * // Create a set with initial values
+   * const immutableSet = HashSet.make(1, 2, 3)
+   *
+   * // Use mutate to perform multiple operations efficiently
+   * const result = pipe(
+   *   immutableSet,
+   *   HashSet.mutate((set) => {
+   *     assert.equal(Object.is(immutableSet, set), false)
+   *
+   *     // The set is temporarily mutable inside this function
+   *     const mod1 = HashSet.add(set, 4)
+   *     const mod2 = HashSet.remove(set, 1)
+   *     assert.equal(Object.is(mod1, mod2), true) // they are the same object by reference
+   *   })
+   * )
+   *
+   * // The original set is unchanged
+   * assert.equal(Object.is(immutableSet, result), false)
+   * assert.deepStrictEqual(HashSet.toValues(immutableSet).sort(), [1, 2, 3])
+   *
+   * // The result contains the mutations
+   * assert.deepStrictEqual(HashSet.toValues(result).sort(), [2, 3, 4])
+   * ```
+   */
   <A>(f: (set: HashSet<A>) => void): (self: HashSet<A>) => HashSet<A>
+
+  /**
+   * @example {@link mutate} `data-first` API
+   *
+   * ```ts
+   * import { HashSet } from "effect"
+   * import assert from "node:assert/strict"
+   *
+   * // Create a set with initial values
+   * const immutableSet = HashSet.make(1, 2, 3)
+   *
+   * // Use mutate with data-first API
+   * const result = HashSet.mutate(immutableSet, (set) => {
+   *   // The set is temporarily mutable inside this function
+   *   HashSet.add(set, 4)
+   *   HashSet.remove(set, 1)
+   * })
+   *
+   * // The original set is unchanged
+   * assert.equal(Object.is(immutableSet, result), false)
+   * assert.deepStrictEqual(HashSet.toValues(immutableSet).sort(), [1, 2, 3])
+   *
+   * // The result contains the mutations
+   * assert.deepStrictEqual(HashSet.toValues(result).sort(), [2, 3, 4])
+   * ```
+   */
   <A>(self: HashSet<A>, f: (set: HashSet<A>) => void): HashSet<A>
 } = HS.mutate
 


### PR DESCRIPTION
Enhancing the `HashSet` module by introducing extensive inline documentation and detailed examples. 

The added documentation explains various operations' immutability, performance characteristics, and time complexity. Method signatures have been updated to include overloads supporting both data-first and data-last APIs. No changes were made to the underlying logic of the HashSet.